### PR TITLE
Lauriebax/fix dep faster coco eval

### DIFF
--- a/mmdet/datasets/__init__.py
+++ b/mmdet/datasets/__init__.py
@@ -31,7 +31,9 @@ except ImportError:
     import logging
 
     from mmengine.logging import print_log
-    print_log('Could not import OneDL', level=logging.DEBUG)
+    print_log(
+        'Could not import OneDL. Skipping OneDL datasets.',
+        level=logging.DEBUG)
     onedl_dataset_types = []
 from .openimages import OpenImagesChallengeDataset, OpenImagesDataset
 from .refcoco import RefCocoDataset

--- a/mmdet/datasets/transforms/__init__.py
+++ b/mmdet/datasets/transforms/__init__.py
@@ -33,7 +33,9 @@ except ImportError:
     import logging
 
     from mmengine.logging import print_log
-    print_log('Could not import OneDL', level=logging.DEBUG)
+    print_log(
+        'Could not import OneDL. Skipping OneDL datasets.',
+        level=logging.DEBUG)
     onedl_datatypes = []
 
 __all__ = [

--- a/mmdet/evaluation/functional/panoptic_utils.py
+++ b/mmdet/evaluation/functional/panoptic_utils.py
@@ -11,11 +11,7 @@ import mmcv
 import numpy as np
 from mmengine.fileio import get
 
-# A custom value to distinguish instance ID and category ID; need to
-# be greater than the number of categories.
-# For a pixel in the panoptic result map:
-#   pan_id = ins_id * INSTANCE_OFFSET + cat_id
-INSTANCE_OFFSET = 1000
+from mmdet.structures import INSTANCE_OFFSET  # noqa: F401
 
 try:
     from panopticapi.evaluation import OFFSET, VOID, PQStat

--- a/mmdet/evaluation/metrics/faster_coco_metric.py
+++ b/mmdet/evaluation/metrics/faster_coco_metric.py
@@ -10,10 +10,19 @@ from typing import Any, Dict, List, Sequence
 
 import numpy as np
 import torch
-from faster_coco_eval import COCO, COCOeval_faster
 from mmengine.fileio import load
 from mmengine.logging import MMLogger
 from terminaltables import AsciiTable
+
+try:
+    from faster_coco_eval import COCO, COCOeval_faster
+except ImportError:
+    import warnings
+    warnings.warn(
+        'faster_coco_eval is not installed, metrics will not be computed. '
+        'Please install it by: mim install onedl-mmdetection[optional]')
+    COCO = None
+    COCOeval_faster = None
 
 from mmdet.evaluation.metrics import CocoMetric
 from mmdet.registry import METRICS

--- a/mmdet/models/seg_heads/panoptic_fusion_heads/heuristic_fusion_head.py
+++ b/mmdet/models/seg_heads/panoptic_fusion_heads/heuristic_fusion_head.py
@@ -5,8 +5,8 @@ import torch
 from mmengine.structures import InstanceData, PixelData
 from torch import Tensor
 
-from mmdet.evaluation.functional import INSTANCE_OFFSET
 from mmdet.registry import MODELS
+from mmdet.structures import INSTANCE_OFFSET
 from mmdet.utils import InstanceList, OptConfigType, OptMultiConfig, PixelList
 from .base_panoptic_fusion_head import BasePanopticFusionHead
 

--- a/mmdet/models/seg_heads/panoptic_fusion_heads/maskformer_fusion_head.py
+++ b/mmdet/models/seg_heads/panoptic_fusion_heads/maskformer_fusion_head.py
@@ -6,9 +6,8 @@ import torch.nn.functional as F
 from mmengine.structures import InstanceData, PixelData
 from torch import Tensor
 
-from mmdet.evaluation.functional import INSTANCE_OFFSET
 from mmdet.registry import MODELS
-from mmdet.structures import SampleList
+from mmdet.structures import INSTANCE_OFFSET, SampleList
 from mmdet.structures.mask import mask2bbox
 from mmdet.utils import OptConfigType, OptMultiConfig
 from .base_panoptic_fusion_head import BasePanopticFusionHead

--- a/mmdet/structures/__init__.py
+++ b/mmdet/structures/__init__.py
@@ -4,7 +4,14 @@ from .reid_data_sample import ReIDDataSample
 from .track_data_sample import (OptTrackSampleList, TrackDataSample,
                                 TrackSampleList)
 
+# A custom value to distinguish instance ID and category ID in panoptic
+# segmentation maps; needs to be greater than the number of categories.
+# For a pixel in the panoptic result map:
+#   pan_id = ins_id * INSTANCE_OFFSET + cat_id
+INSTANCE_OFFSET = 1000
+
 __all__ = [
     'DetDataSample', 'SampleList', 'OptSampleList', 'TrackDataSample',
-    'TrackSampleList', 'OptTrackSampleList', 'ReIDDataSample'
+    'TrackSampleList', 'OptTrackSampleList', 'ReIDDataSample',
+    'INSTANCE_OFFSET'
 ]

--- a/mmdet/visualization/local_visualizer.py
+++ b/mmdet/visualization/local_visualizer.py
@@ -11,9 +11,8 @@ from mmengine.dist import master_only
 from mmengine.structures import InstanceData, PixelData
 from mmengine.visualization import Visualizer
 
-from ..evaluation import INSTANCE_OFFSET
 from ..registry import VISUALIZERS
-from ..structures import DetDataSample
+from ..structures import INSTANCE_OFFSET, DetDataSample
 from ..structures.mask import BitmapMasks, PolygonMasks, bitmap_to_polygon
 from .palette import _get_adaptive_scales, get_palette, jitter_color
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 
 [project]
 name = "onedl-mmdetection"
-version = "3.4.6"
+version = "3.4.7"
 description = "OneDL Detection Toolbox and Benchmark"
 readme = "README.md"
 authors = [

--- a/tests/test_datasets/test_transforms/test_loading.py
+++ b/tests/test_datasets/test_transforms/test_loading.py
@@ -15,7 +15,7 @@ from mmdet.datasets.transforms import (FilterAnnotations, LoadAnnotations,
                                        LoadImageFromNDArray,
                                        LoadMultiChannelImageFromFiles,
                                        LoadProposals, LoadTrackAnnotations)
-from mmdet.evaluation import INSTANCE_OFFSET
+from mmdet.structures import INSTANCE_OFFSET
 from mmdet.structures.mask import BitmapMasks, PolygonMasks
 
 try:

--- a/tests/test_models/test_import_without_faster_coco_eval.py
+++ b/tests/test_models/test_import_without_faster_coco_eval.py
@@ -1,0 +1,33 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+"""Verify that mmdet.models can be imported without faster_coco_eval.
+
+faster_coco_eval is an optional dependency. Importing models must not
+transitively pull in mmdet.evaluation, which is the only module that requires
+faster_coco_eval at import time.
+"""
+import subprocess
+import sys
+import unittest
+
+
+class TestImportModelsWithoutFasterCocoEval(unittest.TestCase):
+
+    def test_import_models_without_faster_coco_eval(self):
+        """mmdet.models must be importable when faster_coco_eval is absent."""
+        code = (
+            'import sys\n'
+            # Block faster_coco_eval so any attempt to import it raises
+            # ImportError, simulating an environment where it is not installed.
+            "sys.modules['faster_coco_eval'] = None\n"
+            'import mmdet.models\n')
+        result = subprocess.run(
+            [sys.executable, '-c', code],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=('Importing mmdet.models failed when faster_coco_eval is not '
+                 f'installed.\nstderr:\n{result.stderr}'),
+        )

--- a/tests/test_models/test_seg_heads/test_heuristic_fusion_head.py
+++ b/tests/test_models/test_seg_heads/test_heuristic_fusion_head.py
@@ -5,8 +5,8 @@ from mmengine.config import Config
 from mmengine.structures import InstanceData
 from mmengine.testing import assert_allclose
 
-from mmdet.evaluation import INSTANCE_OFFSET
 from mmdet.models.seg_heads.panoptic_fusion_heads import HeuristicFusionHead
+from mmdet.structures import INSTANCE_OFFSET
 
 
 class TestHeuristicFusionHead(unittest.TestCase):

--- a/uv.lock
+++ b/uv.lock
@@ -1706,7 +1706,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/01/42/040e63781d7612f83
 
 [[package]]
 name = "onedl-mmdetection"
-version = "3.4.6"
+version = "3.4.7"
 source = { editable = "." }
 dependencies = [
     { name = "imaug" },


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Importing certain heads depends on having faster_coco_eval installed. Especially for downstream projects this does not make sense. (see https://github.com/VBTI-development/onedl-mmsegmentation/issues/17#issuecomment-4108683202)

## Modification

Moved offending import from evaluation to structures.

## BC-breaking (Optional)

No, value is re-imported at same place for backwards compatibility.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMPreTrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
