### PR TITLE
feat: allow to skip the encoder in a detection transformer

### DIFF
--- a/mmdet/models/layers/transformer/deformable_detr_layers.py
+++ b/mmdet/models/layers/transformer/deformable_detr_layers.py
@@ -37,7 +37,7 @@ class DeformableDetrTransformerEncoder(DetrTransformerEncoder):
             for i in range(self.num_cp):
                 self.layers[i] = checkpoint_wrapper(self.layers[i])
 
-        self.embed_dims = self.layers[0].embed_dims
+        self.embed_dims = self.layer_cfg.self_attn_cfg.embed_dims
 
     def forward(self, query: Tensor, query_pos: Tensor,
                 key_padding_mask: Tensor, spatial_shapes: Tensor,


### PR DESCRIPTION
## Motivation

**Describe the feature**

Newer implemenations of DETR models like LW_DETR or RF-DETR use only a decoder for processing features coming from the backbone. They argue that if you use ViT as a backbone for feature extraction you already have a transformer encoder (see this paper for a sketch of the architecture: https://arxiv.org/pdf/2511.09554).

Disabling the encoder can be done by setting the encoder layers to zero in the configuration file, but a small piece of code needs to be fixed to make this work:

## Modification

** Old code **

Location: `mmdet/models/layers/transformers/deformable_detr_layers.py` 
https://github.com/VBTI-development/onedl-mmdetection/blob/8bba8b54c02aa8e5358e15fb676f1fa90bbb22b6/mmdet/models/layers/transformer/deformable_detr_layers.py#L40

Before (does not work with zero layers):

```py
        self.embed_dims = self.layers[0].embed_dims
```

After (works with zero encoder layers):

```py
        self.embed_dims = self.layer_cfg.self_attn_cfg.embed_dims
```

## BC-breaking (Optional)

No

## Use cases (Optional)

More lightweight detection transformers