### PR TITLE
Chore/reduce mmcv ops deps

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,19 +11,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python 3.10.15
-        uses: actions/setup-python@v5
+      - name: Install uv and set the python version
+        uses: astral-sh/setup-uv@v6
         with:
-          python-version: '3.10.15'
+          activate-environment: true
+          python-version: '3.12'
       - name: Install pre-commit hook
         run: |
-          pip install pre-commit
+          uv pip install pre-commit
           pre-commit install
       - name: Linting
         run: pre-commit run --all-files
       - name: Check docstring coverage
         run: |
-          pip install interrogate
+          uv pip install interrogate
           interrogate -v --ignore-init-method --ignore-module --ignore-nested-functions --ignore-magic --ignore-regex "__repr__" --fail-under 85 mmdet
   uv-lock:
     runs-on: ubuntu-latest
@@ -33,7 +34,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           activate-environment: true
-          python-version: '3.10'
+          python-version: '3.12'
       - name: Check uv.lock file
         run: |
           uv lock --check

--- a/README.md
+++ b/README.md
@@ -191,40 +191,40 @@ Results and models are available in the [model zoo](docs/en/model_zoo.md).
             <li><a href="configs/retinanet">RetinaNet (ICCV'2017)</a></li>
             <li><a href="configs/cascade_rcnn">Cascade R-CNN (CVPR'2018)</a></li>
             <li><a href="configs/yolo">YOLOv3 (ArXiv'2018)</a></li>
-            <li><a href="configs/cornernet">CornerNet (ECCV'2018)</a></li>
+            <li><a href="configs/cornernet">CornerNet (ECCV'2018)</a>*</li>
             <li><a href="configs/grid_rcnn">Grid R-CNN (CVPR'2019)</a></li>
-            <li><a href="configs/guided_anchoring">Guided Anchoring (CVPR'2019)</a></li>
+            <li><a href="configs/guided_anchoring">Guided Anchoring (CVPR'2019)</a>*</li>
             <li><a href="configs/fsaf">FSAF (CVPR'2019)</a></li>
             <li><a href="configs/centernet">CenterNet (CVPR'2019)</a></li>
             <li><a href="configs/libra_rcnn">Libra R-CNN (CVPR'2019)</a></li>
             <li><a href="configs/tridentnet">TridentNet (ICCV'2019)</a></li>
             <li><a href="configs/fcos">FCOS (ICCV'2019)</a></li>
-            <li><a href="configs/reppoints">RepPoints (ICCV'2019)</a></li>
+            <li><a href="configs/reppoints">RepPoints (ICCV'2019)</a>*</li>
             <li><a href="configs/free_anchor">FreeAnchor (NeurIPS'2019)</a></li>
-            <li><a href="configs/cascade_rpn">CascadeRPN (NeurIPS'2019)</a></li>
-            <li><a href="configs/foveabox">Foveabox (TIP'2020)</a></li>
+            <li><a href="configs/cascade_rpn">CascadeRPN (NeurIPS'2019)</a>*</li>
+            <li><a href="configs/foveabox">Foveabox (TIP'2020)</a>*</li>
             <li><a href="configs/double_heads">Double-Head R-CNN (CVPR'2020)</a></li>
             <li><a href="configs/atss">ATSS (CVPR'2020)</a></li>
-            <li><a href="configs/nas_fcos">NAS-FCOS (CVPR'2020)</a></li>
-            <li><a href="configs/centripetalnet">CentripetalNet (CVPR'2020)</a></li>
+            <li><a href="configs/nas_fcos">NAS-FCOS (CVPR'2020)</a>*</li>
+            <li><a href="configs/centripetalnet">CentripetalNet (CVPR'2020)</a>*</li>
             <li><a href="configs/autoassign">AutoAssign (ArXiv'2020)</a></li>
             <li><a href="configs/sabl">Side-Aware Boundary Localization (ECCV'2020)</a></li>
             <li><a href="configs/dynamic_rcnn">Dynamic R-CNN (ECCV'2020)</a></li>
             <li><a href="configs/detr">DETR (ECCV'2020)</a></li>
             <li><a href="configs/paa">PAA (ECCV'2020)</a></li>
-            <li><a href="configs/vfnet">VarifocalNet (CVPR'2021)</a></li>
+            <li><a href="configs/vfnet">VarifocalNet (CVPR'2021)</a>*</li>
             <li><a href="configs/sparse_rcnn">Sparse R-CNN (CVPR'2021)</a></li>
             <li><a href="configs/yolof">YOLOF (CVPR'2021)</a></li>
             <li><a href="configs/yolox">YOLOX (CVPR'2021)</a></li>
-            <li><a href="configs/deformable_detr">Deformable DETR (ICLR'2021)</a></li>
-            <li><a href="configs/tood">TOOD (ICCV'2021)</a></li>
+            <li><a href="configs/deformable_detr">Deformable DETR (ICLR'2021)</a>*</li>
+            <li><a href="configs/tood">TOOD (ICCV'2021)</a>*</li>
             <li><a href="configs/ddod">DDOD (ACM MM'2021)</a></li>
             <li><a href="configs/rtmdet">RTMDet (ArXiv'2022)</a></li>
             <li><a href="configs/conditional_detr">Conditional DETR (ICCV'2021)</a></li>
             <li><a href="configs/dab_detr">DAB-DETR (ICLR'2022)</a></li>
-            <li><a href="configs/dino">DINO (ICLR'2023)</a></li>
-            <li><a href="configs/glip">GLIP (CVPR'2022)</a></li>
-            <li><a href="configs/ddq">DDQ (CVPR'2023)</a></li>
+            <li><a href="configs/dino">DINO (ICLR'2023)</a>*</li>
+            <li><a href="configs/glip">GLIP (CVPR'2022)</a>*</li>
+            <li><a href="configs/ddq">DDQ (CVPR'2023)</a>*</li>
             <li><a href="projects/DiffusionDet">DiffusionDet (ArXiv'2023)</a></li>
             <li><a href="projects/EfficientDet">EfficientDet (CVPR'2020)</a></li>
             <li><a href="projects/ViTDet">ViTDet (ECCV'2022)</a></li>
@@ -241,12 +241,12 @@ Results and models are available in the [model zoo](docs/en/model_zoo.md).
           <li><a href="configs/yolact">YOLACT (ICCV'2019)</a></li>
           <li><a href="configs/instaboost">InstaBoost (ICCV'2019)</a></li>
           <li><a href="configs/solo">SOLO (ECCV'2020)</a></li>
-          <li><a href="configs/point_rend">PointRend (CVPR'2020)</a></li>
+          <li><a href="configs/point_rend">PointRend (CVPR'2020)</a>*</li>
           <li><a href="configs/detectors">DetectoRS (ArXiv'2020)</a></li>
           <li><a href="configs/solov2">SOLOv2 (NeurIPS'2020)</a></li>
           <li><a href="configs/scnet">SCNet (AAAI'2021)</a></li>
           <li><a href="configs/queryinst">QueryInst (ICCV'2021)</a></li>
-          <li><a href="configs/mask2former">Mask2Former (ArXiv'2021)</a></li>
+          <li><a href="configs/mask2former">Mask2Former (ArXiv'2021)</a>*</li>
           <li><a href="configs/condinst">CondInst (ECCV'2020)</a></li>
           <li><a href="projects/SparseInst">SparseInst (CVPR'2022)</a></li>
           <li><a href="configs/rtmdet">RTMDet (ArXiv'2022)</a></li>
@@ -258,7 +258,7 @@ Results and models are available in the [model zoo](docs/en/model_zoo.md).
         <ul>
           <li><a href="configs/panoptic_fpn">Panoptic FPN (CVPR'2019)</a></li>
           <li><a href="configs/maskformer">MaskFormer (NeurIPS'2021)</a></li>
-          <li><a href="configs/mask2former">Mask2Former (ArXiv'2021)</a></li>
+          <li><a href="configs/mask2former">Mask2Former (ArXiv'2021)</a>*</li>
           <li><a href="configs/XDecoder">XDecoder (CVPR'2023)</a></li>
         </ul>
       </td>
@@ -289,7 +289,7 @@ Results and models are available in the [model zoo](docs/en/model_zoo.md).
           <li><b>Lane detection</b></li>
         <ul>
         <ul>
-          <li><a href="configs/clrnet">CLRNet (CVPR'2022)</a></li>
+          <li><a href="configs/clrnet">CLRNet (CVPR'2022)</a>*</li>
         </ul>
         </ul>
       </ul>
@@ -344,12 +344,12 @@ Results and models are available in the [model zoo](docs/en/model_zoo.md).
       <td>
       <ul>
         <li><a href="configs/pafpn">PAFPN (CVPR'2018)</a></li>
-        <li><a href="configs/nas_fpn">NAS-FPN (CVPR'2019)</a></li>
-        <li><a href="configs/carafe">CARAFE (ICCV'2019)</a></li>
+        <li><a href="configs/nas_fpn">NAS-FPN (CVPR'2019)</a>*</li>
+        <li><a href="configs/carafe">CARAFE (ICCV'2019)</a>*</li>
         <li><a href="configs/fpg">FPG (ArXiv'2020)</a></li>
         <li><a href="configs/groie">GRoIE (ICPR'2020)</a></li>
-        <li><a href="configs/dyhead">DyHead (CVPR'2021)</a></li>
-        <li><a href="configs/clrnet">CLRHead (CVPR'2022)</a></li>
+        <li><a href="configs/dyhead">DyHead (CVPR'2021)</a>*</li>
+        <li><a href="configs/clrnet">CLRHead (CVPR'2022)</a>*</li>
       </ul>
       </td>
       <td>
@@ -363,10 +363,10 @@ Results and models are available in the [model zoo](docs/en/model_zoo.md).
         <ul>
           <li><a href="configs/faster_rcnn/faster-rcnn_r50_fpn_ohem_1x_coco.py">OHEM (CVPR'2016)</a></li>
           <li><a href="configs/gn">Group Normalization (ECCV'2018)</a></li>
-          <li><a href="configs/dcn">DCN (ICCV'2017)</a></li>
-          <li><a href="configs/dcnv2">DCNv2 (CVPR'2019)</a></li>
+          <li><a href="configs/dcn">DCN (ICCV'2017)</a>*</li>
+          <li><a href="configs/dcnv2">DCNv2 (CVPR'2019)</a>*</li>
           <li><a href="configs/gn+ws">Weight Standardization (ArXiv'2019)</a></li>
-          <li><a href="configs/pisa">Prime Sample Attention (CVPR'2020)</a></li>
+          <li><a href="configs/pisa">Prime Sample Attention (CVPR'2020)</a>*</li>
           <li><a href="configs/strong_baselines">Strong Baselines (CVPR'2021)</a></li>
           <li><a href="configs/resnet_strikes_back">Resnet strikes back (ArXiv'2021)</a></li>
         </ul>
@@ -376,6 +376,8 @@ Results and models are available in the [model zoo](docs/en/model_zoo.md).
     </tr>
   </tbody>
 </table>
+
+<p><sup>* Requires onedl-mmcv with compiled C++/CUDA extensions for a <b>core architectural component</b> (e.g. deformable convolution, corner pooling, deformable attention, CARAFE upsampling, point sampling, or lane NMS). Note: all detection models also require <code>batched_nms</code> from mmcv.ops at inference time — so you would probably need onedl-mmcv with ops. See the <a href="https://onedl-mmdetection.readthedocs.io/en/latest/notes/faq.html">FAQ</a> for installation instructions.</sup></p>
 
 Some other methods are also supported in [projects using MMDetection](./docs/en/notes/projects.md).
 

--- a/docs/en/notes/faq.md
+++ b/docs/en/notes/faq.md
@@ -40,36 +40,33 @@ About the common questions about PyTorch 2.0's dynamo, you can refer to [here](h
 
 ## Installation
 
-Compatibility issue between MMCV and MMDetection; "ConvWS is already registered in conv layer"; "AssertionError: MMCV==xxx is used but incompatible. Please install mmcv>=xxx, \<=xxx."
+Compatibility issue between onedl-mmcv and onedl-mmdetection; "ConvWS is already registered in conv layer"; "AssertionError: MMCV==xxx is used but incompatible. Please install mmcv>=xxx, \<=xxx."
 
-Compatible MMDetection, MMEngine, and MMCV versions are shown as below. Please choose the correct version of MMCV to avoid installation issues.
+onedl-mmdetection requires [onedl-mmcv](https://github.com/vbti-development/onedl-mmcv) and [onedl-mmengine](https://github.com/vbti-development/onedl-mmengine). Please follow the [installation instructions](https://onedl-mmdetection.readthedocs.io/en/latest/get_started.html) for the recommended setup.
 
-| MMDetection version |      MMCV version       |     MMEngine version     |
-| :-----------------: | :---------------------: | :----------------------: |
-|        main         |  mmcv>=2.0.0, \<2.2.0   | mmengine>=0.7.1, \<1.0.0 |
-|        3.3.0        |  mmcv>=2.0.0, \<2.2.0   | mmengine>=0.7.1, \<1.0.0 |
-|        3.2.0        |  mmcv>=2.0.0, \<2.2.0   | mmengine>=0.7.1, \<1.0.0 |
-|        3.1.0        |  mmcv>=2.0.0, \<2.1.0   | mmengine>=0.7.1, \<1.0.0 |
-|        3.0.0        |  mmcv>=2.0.0, \<2.1.0   | mmengine>=0.7.1, \<1.0.0 |
-|      3.0.0rc6       | mmcv>=2.0.0rc4, \<2.1.0 | mmengine>=0.6.0, \<1.0.0 |
-|      3.0.0rc5       | mmcv>=2.0.0rc1, \<2.1.0 | mmengine>=0.3.0, \<1.0.0 |
-|      3.0.0rc4       | mmcv>=2.0.0rc1, \<2.1.0 | mmengine>=0.3.0, \<1.0.0 |
-|      3.0.0rc3       | mmcv>=2.0.0rc1, \<2.1.0 | mmengine>=0.3.0, \<1.0.0 |
-|      3.0.0rc2       | mmcv>=2.0.0rc1, \<2.1.0 | mmengine>=0.1.0, \<1.0.0 |
-|      3.0.0rc1       | mmcv>=2.0.0rc1, \<2.1.0 | mmengine>=0.1.0, \<1.0.0 |
-|      3.0.0rc0       | mmcv>=2.0.0rc1, \<2.1.0 | mmengine>=0.1.0, \<1.0.0 |
+**onedl-mmcv comes in two variants:**
 
-**Note:**
+| Variant                  | How to install                                            | CUDA ops included? |
+| ------------------------ | --------------------------------------------------------- | ------------------ |
+| Lite (pure Python)       | `pip install onedl-mmcv` (from PyPI)                      | No                 |
+| Full (with compiled ops) | Install from [mmwheel.onedl.ai](https://mmwheel.onedl.ai) | Yes                |
 
-1. If you want to install mmdet-v2.x, the compatible MMDetection and MMCV versions table can be found at [here](https://onedl-mmdetection.readthedocs.io/en/stable/faq.html#installation). Please choose the correct version of MMCV to avoid installation issues.
-2. In MMCV-v2.x, `mmcv-full` is rename to `mmcv`, if you want to install `mmcv` without CUDA ops, you can install `mmcv-lite`.
+Many models marked with `*` in the model zoo require the **full** variant with compiled CUDA/C++ ops.
+Furthermore almost all models use batched_nms in their output so the full variant is recommended.
 
-- "No module named 'mmcv.ops'"; "No module named 'mmcv.\_ext'".
+- "No module named 'mmcv.ops'"; "No module named 'mmcv.\_ext'"; `RuntimeError: ... requires mmcv to be compiled with C++/CUDA extensions`.
 
-  1. Uninstall existing `mmcv-lite` in the environment using `pip uninstall mmcv-lite`.
-  2. Install `mmcv` following the [installation instruction](https://onedl-mmcv.readthedocs.io/en/2.x/get_started/installation.html).
+  You have the lite variant of onedl-mmcv installed (from PyPI), which does not include compiled ops. To fix this:
 
-- "Microsoft Visual C++ 14.0 or graeter is required" during installation on Windows.
+  1. Uninstall the current version:
+     ```bash
+     pip uninstall onedl-mmcv
+     ```
+  2. Install the full variant (with ops) from [mmwheel.onedl.ai](https://mmwheel.onedl.ai), selecting the wheel that matches your PyTorch and CUDA version.
+
+  See also: [## What should I do if I get `mmcv._ext` or `mmcv.ops` import errors?](#what-should-i-do-if-i-get-mmcv_ext-or-mmcvops-import-errors) below, and the [onedl-mmcv FAQ](https://onedl-mmcv.readthedocs.io/en/latest/faq.html).
+
+- "Microsoft Visual C++ 14.0 or greater is required" during installation on Windows.
 
   This error happens when building the 'pycocotools.\_mask' extension of pycocotools and the environment lacks corresponding C++ compilation dependencies. You need to download it at Microsoft officials [visual-cpp-build-tools](https://visualstudio.microsoft.com/zh-hans/visual-cpp-build-tools/),  select the "Use C ++ Desktop Development" option to install the minimum dependencies, and then reinstall pycocotools.
 
@@ -110,14 +107,33 @@ Compatible MMDetection, MMEngine, and MMCV versions are shown as below. Please c
   PYTHONPATH="$(dirname $0)/..":$PYTHONPATH
   ```
 
+## What should I do if I get `mmcv._ext` or `mmcv.ops` import errors?
+
+All inference models in onedl-mmdetection use the `batched_nms` operation from onedl-mmcv. These errors usually mean that the required custom CUDA/C++ operators from MMCV (or onedl-mmcv) are not available in your environment. This can happen if:
+
+- You installed the lightweight (pure Python) version of MMCV/onedl-mmcv, which does not include the compiled ops (including `batched_nms`).
+- The compiled ops are not compatible with your PyTorch/CUDA version.
+- There was an installation or build error.
+
+**How to fix:**
+
+1. Uninstall the current MMCV/onedl-mmcv:
+
+```bash
+pip uninstall mmcv mmcv-full onedl-mmcv
+```
+
+2. Install the full version of onedl-mmcv (with ops) that matches your CUDA and PyTorch version. See the official instructions:
+   https://onedl-mmcv.readthedocs.io/en/latest/faq.html
+3. If you are using a CPU-only environment, make sure to install the correct CPU-only wheel.
+4. If you built from source, ensure the build completed successfully and matches your environment.
+
+**Reference:**
+
+- [onedl-mmcv FAQ: ImportError: cannot import name 'get_compiler_version' / 'get_cuda_version'](https://onedl-mmcv.readthedocs.io/en/latest/faq.html)
+- [onedl-mmcv Installation Guide](https://onedl-mmcv.readthedocs.io/en/latest/get_started/installation.html)
+
 ## PyTorch/CUDA Environment
-
-- "RTX 30 series card fails when building MMCV or MMDet"
-
-  1. Temporary work-around: do `MMCV_WITH_OPS=1 MMCV_CUDA_ARGS='-gencode=arch=compute_80,code=sm_80' pip install -e .`.
-     The common issue is `nvcc fatal : Unsupported gpu architecture 'compute_86'`. This means that the compiler should optimize for sm_86, i.e., nvidia 30 series card, but such optimizations have not been supported by CUDA toolkit 11.0.
-     This work-around modifies the compile flag by adding `MMCV_CUDA_ARGS='-gencode=arch=compute_80,code=sm_80'`, which tells `nvcc` to optimize for **sm_80**, i.e., Nvidia A100. Although A100 is different from the 30 series card, they use similar ampere architecture. This may hurt the performance but it works.
-  2. PyTorch developers have updated that the default compiler flags should be fixed by [pytorch/pytorch#47585](https://github.com/pytorch/pytorch/pull/47585). So using PyTorch-nightly may also be able to solve the problem, though we have not tested it yet.
 
 - "invalid device function" or "no kernel image is available for execution".
 

--- a/mmdet/apis/inference.py
+++ b/mmdet/apis/inference.py
@@ -7,7 +7,20 @@ from typing import Optional, Sequence, Union
 import numpy as np
 import torch
 import torch.nn as nn
-from mmcv.ops import RoIPool
+
+try:
+    from mmcv.ops import RoIPool
+except ModuleNotFoundError:
+
+    class RoIPool:
+
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError(
+                '`RoIPool` requires mmcv to be compiled with '
+                'C++/CUDA extensions (mmcv._ext). Please reinstall '
+                'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+
 from mmcv.transforms import Compose
 from mmengine.config import Config
 from mmengine.dataset import default_collate

--- a/mmdet/apis/inference.py
+++ b/mmdet/apis/inference.py
@@ -10,15 +10,14 @@ import torch.nn as nn
 
 try:
     from mmcv.ops import RoIPool
-except ModuleNotFoundError:
+except ImportError:
 
     class RoIPool:
 
         def __init__(self, *args, **kwargs):
             raise RuntimeError(
-                '`RoIPool` requires mmcv to be compiled with '
-                'C++/CUDA extensions (mmcv._ext). Please reinstall '
-                'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+                'RoIPool requires mmcv to be compiled with ops. Please '
+                'reinstall onedl-mmcv with CUDA support.')
 
 
 from mmcv.transforms import Compose

--- a/mmdet/evaluation/metrics/dump_odvg_results.py
+++ b/mmdet/evaluation/metrics/dump_odvg_results.py
@@ -3,13 +3,12 @@ from typing import Any, Optional, Sequence
 
 try:
     from mmcv.ops import batched_nms
-except ModuleNotFoundError:
+except ImportError:
 
     def batched_nms(*args, **kwargs):
         raise RuntimeError(
-            '`batched_nms` requires mmcv to be compiled with '
-            'C++/CUDA extensions (mmcv._ext). Please reinstall '
-            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+            'batched_nms requires mmcv to be compiled with ops. Please '
+            'reinstall onedl-mmcv with CUDA support.')
 
 
 from mmengine.evaluator import BaseMetric

--- a/mmdet/evaluation/metrics/dump_odvg_results.py
+++ b/mmdet/evaluation/metrics/dump_odvg_results.py
@@ -1,7 +1,17 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from typing import Any, Optional, Sequence
 
-from mmcv.ops import batched_nms
+try:
+    from mmcv.ops import batched_nms
+except ModuleNotFoundError:
+
+    def batched_nms(*args, **kwargs):
+        raise RuntimeError(
+            '`batched_nms` requires mmcv to be compiled with '
+            'C++/CUDA extensions (mmcv._ext). Please reinstall '
+            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+
 from mmengine.evaluator import BaseMetric
 from mmengine.logging import print_log
 

--- a/mmdet/models/dense_heads/atss_vlfusion_head.py
+++ b/mmdet/models/dense_heads/atss_vlfusion_head.py
@@ -7,7 +7,20 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from mmcv.cnn import Scale
-from mmcv.ops.modulated_deform_conv import ModulatedDeformConv2d
+
+try:
+    from mmcv.ops.modulated_deform_conv import ModulatedDeformConv2d
+except ModuleNotFoundError:
+
+    class ModulatedDeformConv2d:
+
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError(
+                '`ModulatedDeformConv2d` requires mmcv to be compiled with '
+                'C++/CUDA extensions (mmcv._ext). Please reinstall '
+                'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+
 from mmengine.config import ConfigDict
 from mmengine.model import BaseModel
 from mmengine.structures import InstanceData

--- a/mmdet/models/dense_heads/atss_vlfusion_head.py
+++ b/mmdet/models/dense_heads/atss_vlfusion_head.py
@@ -10,15 +10,14 @@ from mmcv.cnn import Scale
 
 try:
     from mmcv.ops.modulated_deform_conv import ModulatedDeformConv2d
-except ModuleNotFoundError:
+except ImportError:
 
     class ModulatedDeformConv2d:
 
         def __init__(self, *args, **kwargs):
             raise RuntimeError(
-                '`ModulatedDeformConv2d` requires mmcv to be compiled with '
-                'C++/CUDA extensions (mmcv._ext). Please reinstall '
-                'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+                'ModulatedDeformConv2d requires mmcv to be compiled with '
+                'ops. Please reinstall onedl-mmcv with CUDA support.')
 
 
 from mmengine.config import ConfigDict

--- a/mmdet/models/dense_heads/base_dense_head.py
+++ b/mmdet/models/dense_heads/base_dense_head.py
@@ -5,7 +5,18 @@ from inspect import signature
 from typing import List, Optional, Tuple
 
 import torch
-from mmcv.ops import batched_nms
+
+try:
+    from mmcv.ops import batched_nms
+except ModuleNotFoundError:
+
+    def batched_nms(*args, **kwargs):
+        raise RuntimeError(
+            '`batched_nms` requires mmcv to be compiled with '
+            'C++/CUDA extensions (mmcv._ext). Please reinstall '
+            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+
 from mmengine.config import ConfigDict
 from mmengine.model import BaseModule, constant_init
 from mmengine.structures import InstanceData

--- a/mmdet/models/dense_heads/base_dense_head.py
+++ b/mmdet/models/dense_heads/base_dense_head.py
@@ -8,13 +8,12 @@ import torch
 
 try:
     from mmcv.ops import batched_nms
-except ModuleNotFoundError:
+except ImportError:
 
     def batched_nms(*args, **kwargs):
         raise RuntimeError(
-            '`batched_nms` requires mmcv to be compiled with '
-            'C++/CUDA extensions (mmcv._ext). Please reinstall '
-            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+            'batched_nms requires mmcv to be compiled with ops. Please '
+            'reinstall onedl-mmcv with CUDA support.')
 
 
 from mmengine.config import ConfigDict

--- a/mmdet/models/dense_heads/cascade_rpn_head.py
+++ b/mmdet/models/dense_heads/cascade_rpn_head.py
@@ -8,15 +8,14 @@ import torch.nn as nn
 
 try:
     from mmcv.ops import DeformConv2d
-except ModuleNotFoundError:
+except ImportError:
 
     class DeformConv2d:
 
         def __init__(self, *args, **kwargs):
             raise RuntimeError(
-                '`DeformConv2d` requires mmcv to be compiled with '
-                'C++/CUDA extensions (mmcv._ext). Please reinstall '
-                'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+                'DeformConv2d requires mmcv to be compiled with ops. Please '
+                'reinstall onedl-mmcv with CUDA support.')
 
 
 from mmengine.config import ConfigDict

--- a/mmdet/models/dense_heads/cascade_rpn_head.py
+++ b/mmdet/models/dense_heads/cascade_rpn_head.py
@@ -5,7 +5,20 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
-from mmcv.ops import DeformConv2d
+
+try:
+    from mmcv.ops import DeformConv2d
+except ModuleNotFoundError:
+
+    class DeformConv2d:
+
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError(
+                '`DeformConv2d` requires mmcv to be compiled with '
+                'C++/CUDA extensions (mmcv._ext). Please reinstall '
+                'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+
 from mmengine.config import ConfigDict
 from mmengine.model import BaseModule, ModuleList
 from mmengine.structures import InstanceData

--- a/mmdet/models/dense_heads/centernet_head.py
+++ b/mmdet/models/dense_heads/centernet_head.py
@@ -6,13 +6,12 @@ import torch.nn as nn
 
 try:
     from mmcv.ops import batched_nms
-except ModuleNotFoundError:
+except ImportError:
 
     def batched_nms(*args, **kwargs):
         raise RuntimeError(
-            '`batched_nms` requires mmcv to be compiled with '
-            'C++/CUDA extensions (mmcv._ext). Please reinstall '
-            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+            'batched_nms requires mmcv to be compiled with ops. Please '
+            'reinstall onedl-mmcv with CUDA support.')
 
 
 from mmengine.config import ConfigDict

--- a/mmdet/models/dense_heads/centernet_head.py
+++ b/mmdet/models/dense_heads/centernet_head.py
@@ -3,7 +3,18 @@ from typing import List, Optional, Tuple
 
 import torch
 import torch.nn as nn
-from mmcv.ops import batched_nms
+
+try:
+    from mmcv.ops import batched_nms
+except ModuleNotFoundError:
+
+    def batched_nms(*args, **kwargs):
+        raise RuntimeError(
+            '`batched_nms` requires mmcv to be compiled with '
+            'C++/CUDA extensions (mmcv._ext). Please reinstall '
+            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+
 from mmengine.config import ConfigDict
 from mmengine.model import bias_init_with_prob, normal_init
 from mmengine.structures import InstanceData

--- a/mmdet/models/dense_heads/centripetal_head.py
+++ b/mmdet/models/dense_heads/centripetal_head.py
@@ -6,15 +6,14 @@ from mmcv.cnn import ConvModule
 
 try:
     from mmcv.ops import DeformConv2d
-except ModuleNotFoundError:
+except ImportError:
 
     class DeformConv2d:
 
         def __init__(self, *args, **kwargs):
             raise RuntimeError(
-                '`DeformConv2d` requires mmcv to be compiled with '
-                'C++/CUDA extensions (mmcv._ext). Please reinstall '
-                'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+                'DeformConv2d requires mmcv to be compiled with ops. Please '
+                'reinstall onedl-mmcv with CUDA support.')
 
 
 from mmengine.model import normal_init

--- a/mmdet/models/dense_heads/centripetal_head.py
+++ b/mmdet/models/dense_heads/centripetal_head.py
@@ -3,7 +3,20 @@ from typing import List, Optional, Tuple
 
 import torch.nn as nn
 from mmcv.cnn import ConvModule
-from mmcv.ops import DeformConv2d
+
+try:
+    from mmcv.ops import DeformConv2d
+except ModuleNotFoundError:
+
+    class DeformConv2d:
+
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError(
+                '`DeformConv2d` requires mmcv to be compiled with '
+                'C++/CUDA extensions (mmcv._ext). Please reinstall '
+                'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+
 from mmengine.model import normal_init
 from torch import Tensor
 

--- a/mmdet/models/dense_heads/corner_head.py
+++ b/mmdet/models/dense_heads/corner_head.py
@@ -9,21 +9,19 @@ from mmcv.cnn import ConvModule
 
 try:
     from mmcv.ops import CornerPool, batched_nms
-except ModuleNotFoundError:
+except ImportError:
 
     class CornerPool:
 
         def __init__(self, *args, **kwargs):
             raise RuntimeError(
-                '`CornerPool` requires mmcv to be compiled with '
-                'C++/CUDA extensions (mmcv._ext). Please reinstall '
-                'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+                'CornerPool requires mmcv to be compiled with ops. Please '
+                'reinstall onedl-mmcv with CUDA support.')
 
     def batched_nms(*args, **kwargs):
         raise RuntimeError(
-            '`batched_nms` requires mmcv to be compiled with '
-            'C++/CUDA extensions (mmcv._ext). Please reinstall '
-            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+            'batched_nms requires mmcv to be compiled with ops. Please '
+            'reinstall onedl-mmcv with CUDA support.')
 
 
 from mmengine.config import ConfigDict

--- a/mmdet/models/dense_heads/corner_head.py
+++ b/mmdet/models/dense_heads/corner_head.py
@@ -6,7 +6,26 @@ from typing import List, Optional, Sequence, Tuple
 import torch
 import torch.nn as nn
 from mmcv.cnn import ConvModule
-from mmcv.ops import CornerPool, batched_nms
+
+try:
+    from mmcv.ops import CornerPool, batched_nms
+except ModuleNotFoundError:
+
+    class CornerPool:
+
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError(
+                '`CornerPool` requires mmcv to be compiled with '
+                'C++/CUDA extensions (mmcv._ext). Please reinstall '
+                'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+    def batched_nms(*args, **kwargs):
+        raise RuntimeError(
+            '`batched_nms` requires mmcv to be compiled with '
+            'C++/CUDA extensions (mmcv._ext). Please reinstall '
+            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+
 from mmengine.config import ConfigDict
 from mmengine.model import BaseModule, bias_init_with_prob
 from mmengine.structures import InstanceData

--- a/mmdet/models/dense_heads/dense_test_mixins.py
+++ b/mmdet/models/dense_heads/dense_test_mixins.py
@@ -4,7 +4,18 @@ import warnings
 from inspect import signature
 
 import torch
-from mmcv.ops import batched_nms
+
+try:
+    from mmcv.ops import batched_nms
+except ModuleNotFoundError:
+
+    def batched_nms(*args, **kwargs):
+        raise RuntimeError(
+            '`batched_nms` requires mmcv to be compiled with '
+            'C++/CUDA extensions (mmcv._ext). Please reinstall '
+            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+
 from mmengine.structures import InstanceData
 
 from mmdet.structures.bbox import bbox_mapping_back

--- a/mmdet/models/dense_heads/dense_test_mixins.py
+++ b/mmdet/models/dense_heads/dense_test_mixins.py
@@ -7,13 +7,12 @@ import torch
 
 try:
     from mmcv.ops import batched_nms
-except ModuleNotFoundError:
+except ImportError:
 
     def batched_nms(*args, **kwargs):
         raise RuntimeError(
-            '`batched_nms` requires mmcv to be compiled with '
-            'C++/CUDA extensions (mmcv._ext). Please reinstall '
-            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+            'batched_nms requires mmcv to be compiled with ops. Please '
+            'reinstall onedl-mmcv with CUDA support.')
 
 
 from mmengine.structures import InstanceData

--- a/mmdet/models/dense_heads/fovea_head.py
+++ b/mmdet/models/dense_heads/fovea_head.py
@@ -4,7 +4,20 @@ from typing import Dict, List, Optional, Tuple
 import torch
 import torch.nn as nn
 from mmcv.cnn import ConvModule
-from mmcv.ops import DeformConv2d
+
+try:
+    from mmcv.ops import DeformConv2d
+except ModuleNotFoundError:
+
+    class DeformConv2d:
+
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError(
+                '`DeformConv2d` requires mmcv to be compiled with '
+                'C++/CUDA extensions (mmcv._ext). Please reinstall '
+                'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+
 from mmengine.config import ConfigDict
 from mmengine.model import BaseModule
 from mmengine.structures import InstanceData

--- a/mmdet/models/dense_heads/fovea_head.py
+++ b/mmdet/models/dense_heads/fovea_head.py
@@ -7,15 +7,14 @@ from mmcv.cnn import ConvModule
 
 try:
     from mmcv.ops import DeformConv2d
-except ModuleNotFoundError:
+except ImportError:
 
     class DeformConv2d:
 
         def __init__(self, *args, **kwargs):
             raise RuntimeError(
-                '`DeformConv2d` requires mmcv to be compiled with '
-                'C++/CUDA extensions (mmcv._ext). Please reinstall '
-                'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+                'DeformConv2d requires mmcv to be compiled with ops. Please '
+                'reinstall onedl-mmcv with CUDA support.')
 
 
 from mmengine.config import ConfigDict

--- a/mmdet/models/dense_heads/ga_retina_head.py
+++ b/mmdet/models/dense_heads/ga_retina_head.py
@@ -6,15 +6,14 @@ from mmcv.cnn import ConvModule
 
 try:
     from mmcv.ops import MaskedConv2d
-except ModuleNotFoundError:
+except ImportError:
 
     class MaskedConv2d:
 
         def __init__(self, *args, **kwargs):
             raise RuntimeError(
-                '`MaskedConv2d` requires mmcv to be compiled with '
-                'C++/CUDA extensions (mmcv._ext). Please reinstall '
-                'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+                'MaskedConv2d requires mmcv to be compiled with ops. Please '
+                'reinstall onedl-mmcv with CUDA support.')
 
 
 from torch import Tensor

--- a/mmdet/models/dense_heads/ga_retina_head.py
+++ b/mmdet/models/dense_heads/ga_retina_head.py
@@ -3,7 +3,20 @@ from typing import Tuple
 
 import torch.nn as nn
 from mmcv.cnn import ConvModule
-from mmcv.ops import MaskedConv2d
+
+try:
+    from mmcv.ops import MaskedConv2d
+except ModuleNotFoundError:
+
+    class MaskedConv2d:
+
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError(
+                '`MaskedConv2d` requires mmcv to be compiled with '
+                'C++/CUDA extensions (mmcv._ext). Please reinstall '
+                'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+
 from torch import Tensor
 
 from mmdet.registry import MODELS

--- a/mmdet/models/dense_heads/ga_rpn_head.py
+++ b/mmdet/models/dense_heads/ga_rpn_head.py
@@ -8,13 +8,11 @@ import torch.nn.functional as F
 
 try:
     from mmcv.ops import nms
-except ModuleNotFoundError:
+except ImportError:
 
     def nms(*args, **kwargs):
-        raise RuntimeError(
-            '`nms` requires mmcv to be compiled with '
-            'C++/CUDA extensions (mmcv._ext). Please reinstall '
-            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+        raise RuntimeError('nms requires mmcv to be compiled with ops. Please '
+                           'reinstall onedl-mmcv with CUDA support.')
 
 
 from mmengine.structures import InstanceData

--- a/mmdet/models/dense_heads/ga_rpn_head.py
+++ b/mmdet/models/dense_heads/ga_rpn_head.py
@@ -5,7 +5,18 @@ from typing import List, Tuple
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from mmcv.ops import nms
+
+try:
+    from mmcv.ops import nms
+except ModuleNotFoundError:
+
+    def nms(*args, **kwargs):
+        raise RuntimeError(
+            '`nms` requires mmcv to be compiled with '
+            'C++/CUDA extensions (mmcv._ext). Please reinstall '
+            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+
 from mmengine.structures import InstanceData
 from torch import Tensor
 

--- a/mmdet/models/dense_heads/guided_anchor_head.py
+++ b/mmdet/models/dense_heads/guided_anchor_head.py
@@ -6,23 +6,21 @@ import torch.nn as nn
 
 try:
     from mmcv.ops import DeformConv2d, MaskedConv2d
-except ModuleNotFoundError:
+except ImportError:
 
     class DeformConv2d:
 
         def __init__(self, *args, **kwargs):
             raise RuntimeError(
-                '`DeformConv2d` requires mmcv to be compiled with '
-                'C++/CUDA extensions (mmcv._ext). Please reinstall '
-                'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+                'DeformConv2d requires mmcv to be compiled with ops. Please '
+                'reinstall onedl-mmcv with CUDA support.')
 
     class MaskedConv2d:
 
         def __init__(self, *args, **kwargs):
             raise RuntimeError(
-                '`MaskedConv2d` requires mmcv to be compiled with '
-                'C++/CUDA extensions (mmcv._ext). Please reinstall '
-                'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+                'MaskedConv2d requires mmcv to be compiled with ops. Please '
+                'reinstall onedl-mmcv with CUDA support.')
 
 
 from mmengine.model import BaseModule

--- a/mmdet/models/dense_heads/guided_anchor_head.py
+++ b/mmdet/models/dense_heads/guided_anchor_head.py
@@ -3,7 +3,28 @@ from typing import List, Optional, Tuple
 
 import torch
 import torch.nn as nn
-from mmcv.ops import DeformConv2d, MaskedConv2d
+
+try:
+    from mmcv.ops import DeformConv2d, MaskedConv2d
+except ModuleNotFoundError:
+
+    class DeformConv2d:
+
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError(
+                '`DeformConv2d` requires mmcv to be compiled with '
+                'C++/CUDA extensions (mmcv._ext). Please reinstall '
+                'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+    class MaskedConv2d:
+
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError(
+                '`MaskedConv2d` requires mmcv to be compiled with '
+                'C++/CUDA extensions (mmcv._ext). Please reinstall '
+                'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+
 from mmengine.model import BaseModule
 from mmengine.structures import InstanceData
 from torch import Tensor

--- a/mmdet/models/dense_heads/mask2former_head.py
+++ b/mmdet/models/dense_heads/mask2former_head.py
@@ -6,7 +6,18 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from mmcv.cnn import Conv2d
-from mmcv.ops import point_sample
+
+try:
+    from mmcv.ops import point_sample
+except ModuleNotFoundError:
+
+    def point_sample(*args, **kwargs):
+        raise RuntimeError(
+            '`point_sample` requires mmcv to be compiled with '
+            'C++/CUDA extensions (mmcv._ext). Please reinstall '
+            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+
 from mmengine.model import ModuleList, caffe2_xavier_init
 from mmengine.structures import InstanceData
 from torch import Tensor

--- a/mmdet/models/dense_heads/mask2former_head.py
+++ b/mmdet/models/dense_heads/mask2former_head.py
@@ -9,13 +9,12 @@ from mmcv.cnn import Conv2d
 
 try:
     from mmcv.ops import point_sample
-except ModuleNotFoundError:
+except ImportError:
 
     def point_sample(*args, **kwargs):
         raise RuntimeError(
-            '`point_sample` requires mmcv to be compiled with '
-            'C++/CUDA extensions (mmcv._ext). Please reinstall '
-            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+            'point_sample requires mmcv to be compiled with ops. Please '
+            'reinstall onedl-mmcv with CUDA support.')
 
 
 from mmengine.model import ModuleList, caffe2_xavier_init

--- a/mmdet/models/dense_heads/reppoints_head.py
+++ b/mmdet/models/dense_heads/reppoints_head.py
@@ -8,15 +8,14 @@ from mmcv.cnn import ConvModule
 
 try:
     from mmcv.ops import DeformConv2d
-except ModuleNotFoundError:
+except ImportError:
 
     class DeformConv2d:
 
         def __init__(self, *args, **kwargs):
             raise RuntimeError(
-                '`DeformConv2d` requires mmcv to be compiled with '
-                'C++/CUDA extensions (mmcv._ext). Please reinstall '
-                'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+                'DeformConv2d requires mmcv to be compiled with ops. Please '
+                'reinstall onedl-mmcv with CUDA support.')
 
 
 from mmengine.config import ConfigDict

--- a/mmdet/models/dense_heads/reppoints_head.py
+++ b/mmdet/models/dense_heads/reppoints_head.py
@@ -5,7 +5,20 @@ import numpy as np
 import torch
 import torch.nn as nn
 from mmcv.cnn import ConvModule
-from mmcv.ops import DeformConv2d
+
+try:
+    from mmcv.ops import DeformConv2d
+except ModuleNotFoundError:
+
+    class DeformConv2d:
+
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError(
+                '`DeformConv2d` requires mmcv to be compiled with '
+                'C++/CUDA extensions (mmcv._ext). Please reinstall '
+                'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+
 from mmengine.config import ConfigDict
 from mmengine.structures import InstanceData
 from torch import Tensor

--- a/mmdet/models/dense_heads/rpn_head.py
+++ b/mmdet/models/dense_heads/rpn_head.py
@@ -9,13 +9,12 @@ from mmcv.cnn import ConvModule
 
 try:
     from mmcv.ops import batched_nms
-except ModuleNotFoundError:
+except ImportError:
 
     def batched_nms(*args, **kwargs):
         raise RuntimeError(
-            '`batched_nms` requires mmcv to be compiled with '
-            'C++/CUDA extensions (mmcv._ext). Please reinstall '
-            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+            'batched_nms requires mmcv to be compiled with ops. Please '
+            'reinstall onedl-mmcv with CUDA support.')
 
 
 from mmengine.config import ConfigDict

--- a/mmdet/models/dense_heads/rpn_head.py
+++ b/mmdet/models/dense_heads/rpn_head.py
@@ -6,7 +6,18 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from mmcv.cnn import ConvModule
-from mmcv.ops import batched_nms
+
+try:
+    from mmcv.ops import batched_nms
+except ModuleNotFoundError:
+
+    def batched_nms(*args, **kwargs):
+        raise RuntimeError(
+            '`batched_nms` requires mmcv to be compiled with '
+            'C++/CUDA extensions (mmcv._ext). Please reinstall '
+            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+
 from mmengine.config import ConfigDict
 from mmengine.structures import InstanceData
 from torch import Tensor

--- a/mmdet/models/dense_heads/rtmdet_ins_head.py
+++ b/mmdet/models/dense_heads/rtmdet_ins_head.py
@@ -10,13 +10,12 @@ from mmcv.cnn import ConvModule, is_norm
 
 try:
     from mmcv.ops import batched_nms
-except ModuleNotFoundError:
+except ImportError:
 
     def batched_nms(*args, **kwargs):
         raise RuntimeError(
-            '`batched_nms` requires mmcv to be compiled with '
-            'C++/CUDA extensions (mmcv._ext). Please reinstall '
-            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+            'batched_nms requires mmcv to be compiled with ops. Please '
+            'reinstall onedl-mmcv with CUDA support.')
 
 
 from mmengine.model import (BaseModule, bias_init_with_prob, constant_init,

--- a/mmdet/models/dense_heads/rtmdet_ins_head.py
+++ b/mmdet/models/dense_heads/rtmdet_ins_head.py
@@ -7,7 +7,18 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from mmcv.cnn import ConvModule, is_norm
-from mmcv.ops import batched_nms
+
+try:
+    from mmcv.ops import batched_nms
+except ModuleNotFoundError:
+
+    def batched_nms(*args, **kwargs):
+        raise RuntimeError(
+            '`batched_nms` requires mmcv to be compiled with '
+            'C++/CUDA extensions (mmcv._ext). Please reinstall '
+            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+
 from mmengine.model import (BaseModule, bias_init_with_prob, constant_init,
                             normal_init)
 from mmengine.structures import InstanceData

--- a/mmdet/models/dense_heads/tood_head.py
+++ b/mmdet/models/dense_heads/tood_head.py
@@ -5,7 +5,18 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from mmcv.cnn import ConvModule, Scale
-from mmcv.ops import deform_conv2d
+
+try:
+    from mmcv.ops import deform_conv2d
+except ModuleNotFoundError:
+
+    def deform_conv2d(*args, **kwargs):
+        raise RuntimeError(
+            '`deform_conv2d` requires mmcv to be compiled with '
+            'C++/CUDA extensions (mmcv._ext). Please reinstall '
+            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+
 from mmengine import MessageHub
 from mmengine.config import ConfigDict
 from mmengine.model import bias_init_with_prob, normal_init

--- a/mmdet/models/dense_heads/tood_head.py
+++ b/mmdet/models/dense_heads/tood_head.py
@@ -8,13 +8,12 @@ from mmcv.cnn import ConvModule, Scale
 
 try:
     from mmcv.ops import deform_conv2d
-except ModuleNotFoundError:
+except ImportError:
 
     def deform_conv2d(*args, **kwargs):
         raise RuntimeError(
-            '`deform_conv2d` requires mmcv to be compiled with '
-            'C++/CUDA extensions (mmcv._ext). Please reinstall '
-            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+            'deform_conv2d requires mmcv to be compiled with ops. Please '
+            'reinstall onedl-mmcv with CUDA support.')
 
 
 from mmengine import MessageHub

--- a/mmdet/models/dense_heads/vfnet_head.py
+++ b/mmdet/models/dense_heads/vfnet_head.py
@@ -8,15 +8,14 @@ from mmcv.cnn import ConvModule, Scale
 
 try:
     from mmcv.ops import DeformConv2d
-except ModuleNotFoundError:
+except ImportError:
 
     class DeformConv2d:
 
         def __init__(self, *args, **kwargs):
             raise RuntimeError(
-                '`DeformConv2d` requires mmcv to be compiled with '
-                'C++/CUDA extensions (mmcv._ext). Please reinstall '
-                'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+                'DeformConv2d requires mmcv to be compiled with ops. Please '
+                'reinstall onedl-mmcv with CUDA support.')
 
 
 from torch import Tensor

--- a/mmdet/models/dense_heads/vfnet_head.py
+++ b/mmdet/models/dense_heads/vfnet_head.py
@@ -5,7 +5,20 @@ import numpy as np
 import torch
 import torch.nn as nn
 from mmcv.cnn import ConvModule, Scale
-from mmcv.ops import DeformConv2d
+
+try:
+    from mmcv.ops import DeformConv2d
+except ModuleNotFoundError:
+
+    class DeformConv2d:
+
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError(
+                '`DeformConv2d` requires mmcv to be compiled with '
+                'C++/CUDA extensions (mmcv._ext). Please reinstall '
+                'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+
 from torch import Tensor
 
 from mmdet.registry import MODELS, TASK_UTILS

--- a/mmdet/models/dense_heads/yolox_head.py
+++ b/mmdet/models/dense_heads/yolox_head.py
@@ -6,7 +6,18 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from mmcv.cnn import ConvModule, DepthwiseSeparableConvModule
-from mmcv.ops.nms import batched_nms
+
+try:
+    from mmcv.ops.nms import batched_nms
+except ModuleNotFoundError:
+
+    def batched_nms(*args, **kwargs):
+        raise RuntimeError(
+            '`batched_nms` requires mmcv to be compiled with '
+            'C++/CUDA extensions (mmcv._ext). Please reinstall '
+            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+
 from mmengine.config import ConfigDict
 from mmengine.model import bias_init_with_prob
 from mmengine.structures import InstanceData

--- a/mmdet/models/dense_heads/yolox_head.py
+++ b/mmdet/models/dense_heads/yolox_head.py
@@ -9,13 +9,12 @@ from mmcv.cnn import ConvModule, DepthwiseSeparableConvModule
 
 try:
     from mmcv.ops.nms import batched_nms
-except ModuleNotFoundError:
+except ImportError:
 
     def batched_nms(*args, **kwargs):
         raise RuntimeError(
-            '`batched_nms` requires mmcv to be compiled with '
-            'C++/CUDA extensions (mmcv._ext). Please reinstall '
-            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+            'batched_nms requires mmcv to be compiled with ops. Please '
+            'reinstall onedl-mmcv with CUDA support.')
 
 
 from mmengine.config import ConfigDict

--- a/mmdet/models/detectors/ddq_detr.py
+++ b/mmdet/models/detectors/ddq_detr.py
@@ -6,21 +6,19 @@ import torch
 
 try:
     from mmcv.ops import MultiScaleDeformableAttention, batched_nms
-except ModuleNotFoundError:
+except ImportError:
 
     class MultiScaleDeformableAttention:
 
         def __init__(self, *args, **kwargs):
             raise RuntimeError(
-                '`MultiScaleDeformableAttention` requires mmcv to be '
-                'compiled with C++/CUDA extensions (mmcv._ext). '
-                'Please reinstall onedl-mmcv with CUDA support.')
+                'MultiScaleDeformableAttention requires mmcv to be compiled '
+                'with ops. Please reinstall onedl-mmcv with CUDA support.')
 
     def batched_nms(*args, **kwargs):
         raise RuntimeError(
-            '`batched_nms` requires mmcv to be compiled with '
-            'C++/CUDA extensions (mmcv._ext). Please reinstall '
-            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+            'batched_nms requires mmcv to be compiled with ops. Please '
+            'reinstall onedl-mmcv with CUDA support.')
 
 
 from torch import Tensor, nn

--- a/mmdet/models/detectors/ddq_detr.py
+++ b/mmdet/models/detectors/ddq_detr.py
@@ -3,7 +3,26 @@ from typing import Dict, Tuple
 
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch
-from mmcv.ops import MultiScaleDeformableAttention, batched_nms
+
+try:
+    from mmcv.ops import MultiScaleDeformableAttention, batched_nms
+except ModuleNotFoundError:
+
+    class MultiScaleDeformableAttention:
+
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError(
+                '`MultiScaleDeformableAttention` requires mmcv to be '
+                'compiled with C++/CUDA extensions (mmcv._ext). '
+                'Please reinstall onedl-mmcv with CUDA support.')
+
+    def batched_nms(*args, **kwargs):
+        raise RuntimeError(
+            '`batched_nms` requires mmcv to be compiled with '
+            'C++/CUDA extensions (mmcv._ext). Please reinstall '
+            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+
 from torch import Tensor, nn
 from torch.nn.init import normal_
 

--- a/mmdet/models/detectors/deformable_detr.py
+++ b/mmdet/models/detectors/deformable_detr.py
@@ -4,7 +4,20 @@ from typing import Dict, Tuple
 
 import torch
 import torch.nn.functional as F
-from mmcv.cnn.bricks.transformer import MultiScaleDeformableAttention
+
+try:
+    from mmcv.cnn.bricks.transformer import MultiScaleDeformableAttention
+except ImportError:
+
+    class MultiScaleDeformableAttention:
+
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError(
+                '`MultiScaleDeformableAttention` requires mmcv to be '
+                'compiled with C++/CUDA extensions (mmcv._ext). '
+                'Please reinstall onedl-mmcv with CUDA support.')
+
+
 from mmengine.model import xavier_init
 from torch import Tensor, nn
 from torch.nn.init import normal_

--- a/mmdet/models/detectors/deformable_detr.py
+++ b/mmdet/models/detectors/deformable_detr.py
@@ -13,9 +13,8 @@ except ImportError:
 
         def __init__(self, *args, **kwargs):
             raise RuntimeError(
-                '`MultiScaleDeformableAttention` requires mmcv to be '
-                'compiled with C++/CUDA extensions (mmcv._ext). '
-                'Please reinstall onedl-mmcv with CUDA support.')
+                'MultiScaleDeformableAttention requires mmcv to be compiled '
+                'with ops. Please reinstall onedl-mmcv with CUDA support.')
 
 
 from mmengine.model import xavier_init

--- a/mmdet/models/layers/bbox_nms.py
+++ b/mmdet/models/layers/bbox_nms.py
@@ -5,13 +5,12 @@ import torch
 
 try:
     from mmcv.ops.nms import batched_nms
-except ModuleNotFoundError:
+except ImportError:
 
     def batched_nms(*args, **kwargs):
         raise RuntimeError(
-            '`batched_nms` requires mmcv to be compiled with '
-            'C++/CUDA extensions (mmcv._ext). Please reinstall '
-            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+            'batched_nms requires mmcv to be compiled with ops. Please '
+            'reinstall onedl-mmcv with CUDA support.')
 
 
 from torch import Tensor

--- a/mmdet/models/layers/bbox_nms.py
+++ b/mmdet/models/layers/bbox_nms.py
@@ -2,7 +2,18 @@
 from typing import Optional, Tuple, Union
 
 import torch
-from mmcv.ops.nms import batched_nms
+
+try:
+    from mmcv.ops.nms import batched_nms
+except ModuleNotFoundError:
+
+    def batched_nms(*args, **kwargs):
+        raise RuntimeError(
+            '`batched_nms` requires mmcv to be compiled with '
+            'C++/CUDA extensions (mmcv._ext). Please reinstall '
+            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+
 from torch import Tensor
 
 from mmdet.structures.bbox import bbox_overlaps

--- a/mmdet/models/layers/msdeformattn_pixel_decoder.py
+++ b/mmdet/models/layers/msdeformattn_pixel_decoder.py
@@ -14,9 +14,8 @@ except ImportError:
 
         def __init__(self, *args, **kwargs):
             raise RuntimeError(
-                '`MultiScaleDeformableAttention` requires mmcv to be '
-                'compiled with C++/CUDA extensions (mmcv._ext). '
-                'Please reinstall onedl-mmcv with CUDA support.')
+                'MultiScaleDeformableAttention requires mmcv to be compiled '
+                'with ops. Please reinstall onedl-mmcv with CUDA support.')
 
 
 from mmengine.model import (BaseModule, ModuleList, caffe2_xavier_init,

--- a/mmdet/models/layers/msdeformattn_pixel_decoder.py
+++ b/mmdet/models/layers/msdeformattn_pixel_decoder.py
@@ -5,7 +5,20 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from mmcv.cnn import Conv2d, ConvModule
-from mmcv.cnn.bricks.transformer import MultiScaleDeformableAttention
+
+try:
+    from mmcv.cnn.bricks.transformer import MultiScaleDeformableAttention
+except ImportError:
+
+    class MultiScaleDeformableAttention:
+
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError(
+                '`MultiScaleDeformableAttention` requires mmcv to be '
+                'compiled with C++/CUDA extensions (mmcv._ext). '
+                'Please reinstall onedl-mmcv with CUDA support.')
+
+
 from mmengine.model import (BaseModule, ModuleList, caffe2_xavier_init,
                             normal_init, xavier_init)
 from torch import Tensor

--- a/mmdet/models/layers/transformer/ddq_detr_layers.py
+++ b/mmdet/models/layers/transformer/ddq_detr_layers.py
@@ -2,7 +2,18 @@
 import copy
 
 import torch
-from mmcv.ops import batched_nms
+
+try:
+    from mmcv.ops import batched_nms
+except ModuleNotFoundError:
+
+    def batched_nms(*args, **kwargs):
+        raise RuntimeError(
+            '`batched_nms` requires mmcv to be compiled with '
+            'C++/CUDA extensions (mmcv._ext). Please reinstall '
+            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+
 from torch import Tensor, nn
 
 from mmdet.structures.bbox import bbox_cxcywh_to_xyxy

--- a/mmdet/models/layers/transformer/ddq_detr_layers.py
+++ b/mmdet/models/layers/transformer/ddq_detr_layers.py
@@ -5,13 +5,12 @@ import torch
 
 try:
     from mmcv.ops import batched_nms
-except ModuleNotFoundError:
+except ImportError:
 
     def batched_nms(*args, **kwargs):
         raise RuntimeError(
-            '`batched_nms` requires mmcv to be compiled with '
-            'C++/CUDA extensions (mmcv._ext). Please reinstall '
-            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+            'batched_nms requires mmcv to be compiled with ops. Please '
+            'reinstall onedl-mmcv with CUDA support.')
 
 
 from torch import Tensor, nn

--- a/mmdet/models/layers/transformer/deformable_detr_layers.py
+++ b/mmdet/models/layers/transformer/deformable_detr_layers.py
@@ -4,7 +4,20 @@ from typing import Optional, Tuple, Union
 import torch
 from mmcv.cnn import build_norm_layer
 from mmcv.cnn.bricks.transformer import FFN, MultiheadAttention
-from mmcv.ops import MultiScaleDeformableAttention
+
+try:
+    from mmcv.ops import MultiScaleDeformableAttention
+except ModuleNotFoundError:
+
+    class MultiScaleDeformableAttention:
+
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError(
+                '`MultiScaleDeformableAttention` requires mmcv to be '
+                'compiled with C++/CUDA extensions (mmcv._ext). '
+                'Please reinstall onedl-mmcv with CUDA support.')
+
+
 from mmengine.model import ModuleList
 from torch import Tensor, nn
 

--- a/mmdet/models/layers/transformer/deformable_detr_layers.py
+++ b/mmdet/models/layers/transformer/deformable_detr_layers.py
@@ -7,15 +7,14 @@ from mmcv.cnn.bricks.transformer import FFN, MultiheadAttention
 
 try:
     from mmcv.ops import MultiScaleDeformableAttention
-except ModuleNotFoundError:
+except ImportError:
 
     class MultiScaleDeformableAttention:
 
         def __init__(self, *args, **kwargs):
             raise RuntimeError(
-                '`MultiScaleDeformableAttention` requires mmcv to be '
-                'compiled with C++/CUDA extensions (mmcv._ext). '
-                'Please reinstall onedl-mmcv with CUDA support.')
+                'MultiScaleDeformableAttention requires mmcv to be compiled '
+                'with ops. Please reinstall onedl-mmcv with CUDA support.')
 
 
 from mmengine.model import ModuleList

--- a/mmdet/models/layers/transformer/grounding_dino_layers.py
+++ b/mmdet/models/layers/transformer/grounding_dino_layers.py
@@ -3,7 +3,20 @@ import torch
 import torch.nn as nn
 from mmcv.cnn import build_norm_layer
 from mmcv.cnn.bricks.transformer import FFN, MultiheadAttention
-from mmcv.ops import MultiScaleDeformableAttention
+
+try:
+    from mmcv.ops import MultiScaleDeformableAttention
+except ModuleNotFoundError:
+
+    class MultiScaleDeformableAttention:
+
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError(
+                '`MultiScaleDeformableAttention` requires mmcv to be '
+                'compiled with C++/CUDA extensions (mmcv._ext). '
+                'Please reinstall onedl-mmcv with CUDA support.')
+
+
 from mmengine.model import ModuleList
 from torch import Tensor
 

--- a/mmdet/models/layers/transformer/grounding_dino_layers.py
+++ b/mmdet/models/layers/transformer/grounding_dino_layers.py
@@ -6,15 +6,14 @@ from mmcv.cnn.bricks.transformer import FFN, MultiheadAttention
 
 try:
     from mmcv.ops import MultiScaleDeformableAttention
-except ModuleNotFoundError:
+except ImportError:
 
     class MultiScaleDeformableAttention:
 
         def __init__(self, *args, **kwargs):
             raise RuntimeError(
-                '`MultiScaleDeformableAttention` requires mmcv to be '
-                'compiled with C++/CUDA extensions (mmcv._ext). '
-                'Please reinstall onedl-mmcv with CUDA support.')
+                'MultiScaleDeformableAttention requires mmcv to be compiled '
+                'with ops. Please reinstall onedl-mmcv with CUDA support.')
 
 
 from mmengine.model import ModuleList

--- a/mmdet/models/losses/focal_loss.py
+++ b/mmdet/models/losses/focal_loss.py
@@ -2,7 +2,17 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from mmcv.ops import sigmoid_focal_loss as _sigmoid_focal_loss
+
+try:
+    from mmcv.ops import sigmoid_focal_loss as _sigmoid_focal_loss
+except ModuleNotFoundError:
+
+    def _sigmoid_focal_loss(*args, **kwargs):
+        raise RuntimeError(
+            '`sigmoid_focal_loss` requires mmcv to be compiled with '
+            'C++/CUDA extensions (mmcv._ext). Please reinstall '
+            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
 
 from mmdet.registry import MODELS
 from .accuracy import accuracy

--- a/mmdet/models/losses/focal_loss.py
+++ b/mmdet/models/losses/focal_loss.py
@@ -5,13 +5,12 @@ import torch.nn.functional as F
 
 try:
     from mmcv.ops import sigmoid_focal_loss as _sigmoid_focal_loss
-except ModuleNotFoundError:
+except ImportError:
 
     def _sigmoid_focal_loss(*args, **kwargs):
         raise RuntimeError(
-            '`sigmoid_focal_loss` requires mmcv to be compiled with '
-            'C++/CUDA extensions (mmcv._ext). Please reinstall '
-            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+            'sigmoid_focal_loss requires mmcv to be compiled with ops. Please '
+            'reinstall onedl-mmcv with CUDA support.')
 
 
 from mmdet.registry import MODELS

--- a/mmdet/models/necks/dyhead.py
+++ b/mmdet/models/necks/dyhead.py
@@ -1,8 +1,22 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+
 import torch.nn as nn
 import torch.nn.functional as F
 from mmcv.cnn import build_activation_layer, build_norm_layer
-from mmcv.ops.modulated_deform_conv import ModulatedDeformConv2d
+
+try:
+    from mmcv.ops.modulated_deform_conv import ModulatedDeformConv2d
+except ModuleNotFoundError:
+
+    class ModulatedDeformConv2d:
+
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError(
+                '`ModulatedDeformConv2d` requires mmcv to be compiled with '
+                'C++/CUDA extensions (mmcv._ext). Please reinstall '
+                'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+
 from mmengine.model import BaseModule, constant_init, normal_init
 
 from mmdet.registry import MODELS

--- a/mmdet/models/necks/dyhead.py
+++ b/mmdet/models/necks/dyhead.py
@@ -6,15 +6,14 @@ from mmcv.cnn import build_activation_layer, build_norm_layer
 
 try:
     from mmcv.ops.modulated_deform_conv import ModulatedDeformConv2d
-except ModuleNotFoundError:
+except ImportError:
 
     class ModulatedDeformConv2d:
 
         def __init__(self, *args, **kwargs):
             raise RuntimeError(
-                '`ModulatedDeformConv2d` requires mmcv to be compiled with '
-                'C++/CUDA extensions (mmcv._ext). Please reinstall '
-                'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+                'ModulatedDeformConv2d requires mmcv to be compiled with '
+                'ops. Please reinstall onedl-mmcv with CUDA support.')
 
 
 from mmengine.model import BaseModule, constant_init, normal_init

--- a/mmdet/models/necks/fpn_carafe.py
+++ b/mmdet/models/necks/fpn_carafe.py
@@ -1,7 +1,20 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch.nn as nn
 from mmcv.cnn import ConvModule, build_upsample_layer
-from mmcv.ops.carafe import CARAFEPack
+
+try:
+    from mmcv.ops.carafe import CARAFEPack
+except ModuleNotFoundError:
+
+    class CARAFEPack:
+
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError(
+                '`CARAFEPack` requires mmcv to be compiled with '
+                'C++/CUDA extensions (mmcv._ext). Please reinstall '
+                'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+
 from mmengine.model import BaseModule, ModuleList, xavier_init
 
 from mmdet.registry import MODELS

--- a/mmdet/models/necks/fpn_carafe.py
+++ b/mmdet/models/necks/fpn_carafe.py
@@ -4,15 +4,14 @@ from mmcv.cnn import ConvModule, build_upsample_layer
 
 try:
     from mmcv.ops.carafe import CARAFEPack
-except ModuleNotFoundError:
+except ImportError:
 
     class CARAFEPack:
 
         def __init__(self, *args, **kwargs):
             raise RuntimeError(
-                '`CARAFEPack` requires mmcv to be compiled with '
-                'C++/CUDA extensions (mmcv._ext). Please reinstall '
-                'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+                'CARAFEPack requires mmcv to be compiled with ops. Please '
+                'reinstall onedl-mmcv with CUDA support.')
 
 
 from mmengine.model import BaseModule, ModuleList, xavier_init

--- a/mmdet/models/necks/nas_fpn.py
+++ b/mmdet/models/necks/nas_fpn.py
@@ -3,7 +3,28 @@ from typing import List, Tuple
 
 import torch.nn as nn
 from mmcv.cnn import ConvModule
-from mmcv.ops.merge_cells import GlobalPoolingCell, SumCell
+
+try:
+    from mmcv.ops.merge_cells import GlobalPoolingCell, SumCell
+except ModuleNotFoundError:
+
+    class GlobalPoolingCell:
+
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError(
+                '`GlobalPoolingCell` requires mmcv to be compiled with '
+                'C++/CUDA extensions (mmcv._ext). Please reinstall '
+                'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+    class SumCell:
+
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError(
+                '`SumCell` requires mmcv to be compiled with '
+                'C++/CUDA extensions (mmcv._ext). Please reinstall '
+                'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+
 from mmengine.model import BaseModule, ModuleList
 from torch import Tensor
 

--- a/mmdet/models/necks/nas_fpn.py
+++ b/mmdet/models/necks/nas_fpn.py
@@ -6,23 +6,21 @@ from mmcv.cnn import ConvModule
 
 try:
     from mmcv.ops.merge_cells import GlobalPoolingCell, SumCell
-except ModuleNotFoundError:
+except ImportError:
 
     class GlobalPoolingCell:
 
         def __init__(self, *args, **kwargs):
             raise RuntimeError(
-                '`GlobalPoolingCell` requires mmcv to be compiled with '
-                'C++/CUDA extensions (mmcv._ext). Please reinstall '
-                'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+                'GlobalPoolingCell requires mmcv to be compiled with ops. '
+                'Please reinstall onedl-mmcv with CUDA support.')
 
     class SumCell:
 
         def __init__(self, *args, **kwargs):
             raise RuntimeError(
-                '`SumCell` requires mmcv to be compiled with '
-                'C++/CUDA extensions (mmcv._ext). Please reinstall '
-                'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+                'SumCell requires mmcv to be compiled with ops. Please '
+                'reinstall onedl-mmcv with CUDA support.')
 
 
 from mmengine.model import BaseModule, ModuleList

--- a/mmdet/models/necks/nasfcos_fpn.py
+++ b/mmdet/models/necks/nasfcos_fpn.py
@@ -2,7 +2,20 @@
 import torch.nn as nn
 import torch.nn.functional as F
 from mmcv.cnn import ConvModule
-from mmcv.ops.merge_cells import ConcatCell
+
+try:
+    from mmcv.ops.merge_cells import ConcatCell
+except ModuleNotFoundError:
+
+    class ConcatCell:
+
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError(
+                '`ConcatCell` requires mmcv to be compiled with '
+                'C++/CUDA extensions (mmcv._ext). Please reinstall '
+                'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+
 from mmengine.model import BaseModule, caffe2_xavier_init
 
 from mmdet.registry import MODELS

--- a/mmdet/models/necks/nasfcos_fpn.py
+++ b/mmdet/models/necks/nasfcos_fpn.py
@@ -5,15 +5,14 @@ from mmcv.cnn import ConvModule
 
 try:
     from mmcv.ops.merge_cells import ConcatCell
-except ModuleNotFoundError:
+except ImportError:
 
     class ConcatCell:
 
         def __init__(self, *args, **kwargs):
             raise RuntimeError(
-                '`ConcatCell` requires mmcv to be compiled with '
-                'C++/CUDA extensions (mmcv._ext). Please reinstall '
-                'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+                'ConcatCell requires mmcv to be compiled with ops. Please '
+                'reinstall onedl-mmcv with CUDA support.')
 
 
 from mmengine.model import BaseModule, caffe2_xavier_init

--- a/mmdet/models/roi_heads/mask_heads/fcn_mask_head.py
+++ b/mmdet/models/roi_heads/mask_heads/fcn_mask_head.py
@@ -9,15 +9,14 @@ from mmcv.cnn import ConvModule, build_conv_layer, build_upsample_layer
 
 try:
     from mmcv.ops.carafe import CARAFEPack
-except ModuleNotFoundError:
+except ImportError:
 
     class CARAFEPack:
 
         def __init__(self, *args, **kwargs):
             raise RuntimeError(
-                '`CARAFEPack` requires mmcv to be compiled with '
-                'C++/CUDA extensions (mmcv._ext). Please reinstall '
-                'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+                'CARAFEPack requires mmcv to be compiled with ops. Please '
+                'reinstall onedl-mmcv with CUDA support.')
 
 
 from mmengine.config import ConfigDict

--- a/mmdet/models/roi_heads/mask_heads/fcn_mask_head.py
+++ b/mmdet/models/roi_heads/mask_heads/fcn_mask_head.py
@@ -6,7 +6,20 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from mmcv.cnn import ConvModule, build_conv_layer, build_upsample_layer
-from mmcv.ops.carafe import CARAFEPack
+
+try:
+    from mmcv.ops.carafe import CARAFEPack
+except ModuleNotFoundError:
+
+    class CARAFEPack:
+
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError(
+                '`CARAFEPack` requires mmcv to be compiled with '
+                'C++/CUDA extensions (mmcv._ext). Please reinstall '
+                'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+
 from mmengine.config import ConfigDict
 from mmengine.model import BaseModule, ModuleList
 from mmengine.structures import InstanceData

--- a/mmdet/models/roi_heads/mask_heads/mask_point_head.py
+++ b/mmdet/models/roi_heads/mask_heads/mask_point_head.py
@@ -6,7 +6,24 @@ from typing import List, Tuple
 import torch
 import torch.nn as nn
 from mmcv.cnn import ConvModule
-from mmcv.ops import point_sample, rel_roi_point_to_rel_img_point
+
+try:
+    from mmcv.ops import point_sample, rel_roi_point_to_rel_img_point
+except ModuleNotFoundError:
+
+    def point_sample(*args, **kwargs):
+        raise RuntimeError(
+            '`point_sample` requires mmcv to be compiled with C++/CUDA '
+            'extensions (mmcv._ext). Please reinstall onedl-mmcv with '
+            'CUDA support.')
+
+    def rel_roi_point_to_rel_img_point(*args, **kwargs):
+        raise RuntimeError(
+            '`rel_roi_point_to_rel_img_point` requires mmcv to be '
+            'compiled with C++/CUDA extensions (mmcv._ext). '
+            'Please reinstallonedl-mmcv with CUDA support.')
+
+
 from mmengine.model import BaseModule
 from mmengine.structures import InstanceData
 from torch import Tensor

--- a/mmdet/models/roi_heads/mask_heads/mask_point_head.py
+++ b/mmdet/models/roi_heads/mask_heads/mask_point_head.py
@@ -9,19 +9,17 @@ from mmcv.cnn import ConvModule
 
 try:
     from mmcv.ops import point_sample, rel_roi_point_to_rel_img_point
-except ModuleNotFoundError:
+except ImportError:
 
     def point_sample(*args, **kwargs):
         raise RuntimeError(
-            '`point_sample` requires mmcv to be compiled with C++/CUDA '
-            'extensions (mmcv._ext). Please reinstall onedl-mmcv with '
-            'CUDA support.')
+            'point_sample requires mmcv to be compiled with ops. Please '
+            'reinstall onedl-mmcv with CUDA support.')
 
     def rel_roi_point_to_rel_img_point(*args, **kwargs):
         raise RuntimeError(
-            '`rel_roi_point_to_rel_img_point` requires mmcv to be '
-            'compiled with C++/CUDA extensions (mmcv._ext). '
-            'Please reinstallonedl-mmcv with CUDA support.')
+            'rel_roi_point_to_rel_img_point requires mmcv to be compiled '
+            'with ops. Please reinstall onedl-mmcv with CUDA support.')
 
 
 from mmengine.model import BaseModule

--- a/mmdet/models/roi_heads/point_rend_roi_head.py
+++ b/mmdet/models/roi_heads/point_rend_roi_head.py
@@ -4,7 +4,24 @@ from typing import List, Tuple
 
 import torch
 import torch.nn.functional as F
-from mmcv.ops import point_sample, rel_roi_point_to_rel_img_point
+
+try:
+    from mmcv.ops import point_sample, rel_roi_point_to_rel_img_point
+except ModuleNotFoundError:
+
+    def point_sample(*args, **kwargs):
+        raise RuntimeError(
+            '`point_sample` requires mmcv to be compiled with C++/CUDA '
+            'extensions (mmcv._ext). Please reinstall onedl-mmcv with '
+            'CUDA support.')
+
+    def rel_roi_point_to_rel_img_point(*args, **kwargs):
+        raise RuntimeError(
+            '`rel_roi_point_to_rel_img_point` requires mmcv to be '
+            'compiled with C++/CUDA extensions (mmcv._ext). '
+            'Please reinstall onedl-mmcv with CUDA support.')
+
+
 from torch import Tensor
 
 from mmdet.registry import MODELS

--- a/mmdet/models/roi_heads/point_rend_roi_head.py
+++ b/mmdet/models/roi_heads/point_rend_roi_head.py
@@ -7,19 +7,17 @@ import torch.nn.functional as F
 
 try:
     from mmcv.ops import point_sample, rel_roi_point_to_rel_img_point
-except ModuleNotFoundError:
+except ImportError:
 
     def point_sample(*args, **kwargs):
         raise RuntimeError(
-            '`point_sample` requires mmcv to be compiled with C++/CUDA '
-            'extensions (mmcv._ext). Please reinstall onedl-mmcv with '
-            'CUDA support.')
+            'point_sample requires mmcv to be compiled with ops. Please '
+            'reinstall onedl-mmcv with CUDA support.')
 
     def rel_roi_point_to_rel_img_point(*args, **kwargs):
         raise RuntimeError(
-            '`rel_roi_point_to_rel_img_point` requires mmcv to be '
-            'compiled with C++/CUDA extensions (mmcv._ext). '
-            'Please reinstall onedl-mmcv with CUDA support.')
+            'rel_roi_point_to_rel_img_point requires mmcv to be compiled '
+            'with ops. Please reinstall onedl-mmcv with CUDA support.')
 
 
 from torch import Tensor

--- a/mmdet/models/roi_heads/trident_roi_head.py
+++ b/mmdet/models/roi_heads/trident_roi_head.py
@@ -5,13 +5,12 @@ import torch
 
 try:
     from mmcv.ops import batched_nms
-except ModuleNotFoundError:
+except ImportError:
 
     def batched_nms(*args, **kwargs):
         raise RuntimeError(
-            '`batched_nms` requires mmcv to be compiled with '
-            'C++/CUDA extensions (mmcv._ext). Please reinstall '
-            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+            'batched_nms requires mmcv to be compiled with ops. Please '
+            'reinstall onedl-mmcv with CUDA support.')
 
 
 from mmengine.structures import InstanceData

--- a/mmdet/models/roi_heads/trident_roi_head.py
+++ b/mmdet/models/roi_heads/trident_roi_head.py
@@ -2,7 +2,18 @@
 from typing import Tuple
 
 import torch
-from mmcv.ops import batched_nms
+
+try:
+    from mmcv.ops import batched_nms
+except ModuleNotFoundError:
+
+    def batched_nms(*args, **kwargs):
+        raise RuntimeError(
+            '`batched_nms` requires mmcv to be compiled with '
+            'C++/CUDA extensions (mmcv._ext). Please reinstall '
+            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+
 from mmengine.structures import InstanceData
 from torch import Tensor
 

--- a/mmdet/models/task_modules/samplers/score_hlr_sampler.py
+++ b/mmdet/models/task_modules/samplers/score_hlr_sampler.py
@@ -2,7 +2,18 @@
 from typing import Union
 
 import torch
-from mmcv.ops import nms_match
+
+try:
+    from mmcv.ops import nms_match
+except ModuleNotFoundError:
+
+    def nms_match(*args, **kwargs):
+        raise RuntimeError(
+            '`nms_match` requires mmcv to be compiled with '
+            'C++/CUDA extensions (mmcv._ext). Please reinstall '
+            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+
 from mmengine.structures import InstanceData
 from numpy import ndarray
 from torch import Tensor

--- a/mmdet/models/task_modules/samplers/score_hlr_sampler.py
+++ b/mmdet/models/task_modules/samplers/score_hlr_sampler.py
@@ -5,13 +5,12 @@ import torch
 
 try:
     from mmcv.ops import nms_match
-except ModuleNotFoundError:
+except ImportError:
 
     def nms_match(*args, **kwargs):
         raise RuntimeError(
-            '`nms_match` requires mmcv to be compiled with '
-            'C++/CUDA extensions (mmcv._ext). Please reinstall '
-            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+            'nms_match requires mmcv to be compiled with ops. Please '
+            'reinstall onedl-mmcv with CUDA support.')
 
 
 from mmengine.structures import InstanceData

--- a/mmdet/models/test_time_augs/det_tta.py
+++ b/mmdet/models/test_time_augs/det_tta.py
@@ -5,13 +5,12 @@ import torch
 
 try:
     from mmcv.ops import batched_nms
-except ModuleNotFoundError:
+except ImportError:
 
     def batched_nms(*args, **kwargs):
         raise RuntimeError(
-            '`batched_nms` requires mmcv to be compiled with '
-            'C++/CUDA extensions (mmcv._ext). Please reinstall '
-            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+            'batched_nms requires mmcv to be compiled with ops. Please '
+            'reinstall onedl-mmcv with CUDA support.')
 
 
 from mmengine.model import BaseTTAModel

--- a/mmdet/models/test_time_augs/det_tta.py
+++ b/mmdet/models/test_time_augs/det_tta.py
@@ -2,7 +2,18 @@
 from typing import List, Tuple
 
 import torch
-from mmcv.ops import batched_nms
+
+try:
+    from mmcv.ops import batched_nms
+except ModuleNotFoundError:
+
+    def batched_nms(*args, **kwargs):
+        raise RuntimeError(
+            '`batched_nms` requires mmcv to be compiled with '
+            'C++/CUDA extensions (mmcv._ext). Please reinstall '
+            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+
 from mmengine.model import BaseTTAModel
 from mmengine.registry import MODELS
 from mmengine.structures import InstanceData

--- a/mmdet/models/test_time_augs/merge_augs.py
+++ b/mmdet/models/test_time_augs/merge_augs.py
@@ -8,13 +8,11 @@ import torch
 
 try:
     from mmcv.ops import nms
-except ModuleNotFoundError:
+except ImportError:
 
     def nms(*args, **kwargs):
-        raise RuntimeError(
-            '`nms` requires mmcv to be compiled with '
-            'C++/CUDA extensions (mmcv._ext). Please reinstall '
-            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+        raise RuntimeError('nms requires mmcv to be compiled with ops. Please '
+                           'reinstall onedl-mmcv with CUDA support.')
 
 
 from mmengine.config import ConfigDict

--- a/mmdet/models/test_time_augs/merge_augs.py
+++ b/mmdet/models/test_time_augs/merge_augs.py
@@ -5,7 +5,18 @@ from typing import List, Optional, Union
 
 import numpy as np
 import torch
-from mmcv.ops import nms
+
+try:
+    from mmcv.ops import nms
+except ModuleNotFoundError:
+
+    def nms(*args, **kwargs):
+        raise RuntimeError(
+            '`nms` requires mmcv to be compiled with '
+            'C++/CUDA extensions (mmcv._ext). Please reinstall '
+            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+
 from mmengine.config import ConfigDict
 from torch import Tensor
 

--- a/mmdet/models/tracking_heads/mask2former_track_head.py
+++ b/mmdet/models/tracking_heads/mask2former_track_head.py
@@ -7,7 +7,18 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from mmcv.cnn import Conv2d
-from mmcv.ops import point_sample
+
+try:
+    from mmcv.ops import point_sample
+except ModuleNotFoundError:
+
+    def point_sample(*args, **kwargs):
+        raise RuntimeError(
+            '`point_sample` requires mmcv to be compiled with '
+            'C++/CUDA extensions (mmcv._ext). Please reinstall '
+            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+
 from mmengine.model import ModuleList
 from mmengine.model.weight_init import caffe2_xavier_init
 from mmengine.structures import InstanceData

--- a/mmdet/models/tracking_heads/mask2former_track_head.py
+++ b/mmdet/models/tracking_heads/mask2former_track_head.py
@@ -10,13 +10,12 @@ from mmcv.cnn import Conv2d
 
 try:
     from mmcv.ops import point_sample
-except ModuleNotFoundError:
+except ImportError:
 
     def point_sample(*args, **kwargs):
         raise RuntimeError(
-            '`point_sample` requires mmcv to be compiled with '
-            'C++/CUDA extensions (mmcv._ext). Please reinstall '
-            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+            'point_sample requires mmcv to be compiled with ops. Please '
+            'reinstall onedl-mmcv with CUDA support.')
 
 
 from mmengine.model import ModuleList

--- a/mmdet/models/utils/point_sample.py
+++ b/mmdet/models/utils/point_sample.py
@@ -1,6 +1,17 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch
-from mmcv.ops import point_sample
+
+try:
+    from mmcv.ops import point_sample
+except ModuleNotFoundError:
+
+    def point_sample(*args, **kwargs):
+        raise RuntimeError(
+            '`point_sample` requires mmcv to be compiled with '
+            'C++/CUDA extensions (mmcv._ext). Please reinstall '
+            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+
 from torch import Tensor
 
 

--- a/mmdet/models/utils/point_sample.py
+++ b/mmdet/models/utils/point_sample.py
@@ -3,13 +3,12 @@ import torch
 
 try:
     from mmcv.ops import point_sample
-except ModuleNotFoundError:
+except ImportError:
 
     def point_sample(*args, **kwargs):
         raise RuntimeError(
-            '`point_sample` requires mmcv to be compiled with '
-            'C++/CUDA extensions (mmcv._ext). Please reinstall '
-            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+            'point_sample requires mmcv to be compiled with ops. Please '
+            'reinstall onedl-mmcv with CUDA support.')
 
 
 from torch import Tensor

--- a/mmdet/structures/mask/structures.py
+++ b/mmdet/structures/mask/structures.py
@@ -12,13 +12,12 @@ import torch
 
 try:
     from mmcv.ops.roi_align import roi_align
-except ModuleNotFoundError:
+except ImportError:
 
     def roi_align(*args, **kwargs):
         raise RuntimeError(
-            '`roi_align` requires onedl-mmcv to be compiled with '
-            'C++/CUDA extensions (mmcv._ext). Please reinstall '
-            'onedl-mmcv with CUDA support.')
+            'roi_align requires mmcv to be compiled with ops. Please '
+            'reinstall onedl-mmcv with CUDA support.')
 
 
 T = TypeVar('T')

--- a/mmdet/structures/mask/structures.py
+++ b/mmdet/structures/mask/structures.py
@@ -9,7 +9,17 @@ import numpy as np
 import pycocotools.mask as maskUtils
 import shapely.geometry as geometry
 import torch
-from mmcv.ops.roi_align import roi_align
+
+try:
+    from mmcv.ops.roi_align import roi_align
+except ModuleNotFoundError:
+
+    def roi_align(*args, **kwargs):
+        raise RuntimeError(
+            '`roi_align` requires onedl-mmcv to be compiled with '
+            'C++/CUDA extensions (mmcv._ext). Please reinstall '
+            'onedl-mmcv with CUDA support.')
+
 
 T = TypeVar('T')
 

--- a/mmdet/utils/large_image.py
+++ b/mmdet/utils/large_image.py
@@ -2,7 +2,18 @@
 from typing import Sequence, Tuple
 
 import torch
-from mmcv.ops import batched_nms
+
+try:
+    from mmcv.ops import batched_nms
+except ModuleNotFoundError:
+
+    def batched_nms(*args, **kwargs):
+        raise RuntimeError(
+            '`batched_nms` requires mmcv to be compiled with '
+            'C++/CUDA extensions (mmcv._ext). Please reinstall '
+            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+
+
 from mmengine.structures import InstanceData
 
 from mmdet.structures import DetDataSample, SampleList

--- a/mmdet/utils/large_image.py
+++ b/mmdet/utils/large_image.py
@@ -5,13 +5,12 @@ import torch
 
 try:
     from mmcv.ops import batched_nms
-except ModuleNotFoundError:
+except ImportError:
 
     def batched_nms(*args, **kwargs):
         raise RuntimeError(
-            '`batched_nms` requires mmcv to be compiled with '
-            'C++/CUDA extensions (mmcv._ext). Please reinstall '
-            'onedl-mmcv with CUDA support: FORCE_CUDA=1 pip install -e .')
+            'batched_nms requires mmcv to be compiled with ops. Please '
+            'reinstall onedl-mmcv with CUDA support.')
 
 
 from mmengine.structures import InstanceData

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,6 @@ tests = [
     "protobuf",
     "psutil",
     "pytest",
-    "pytest-order",
     "transformers==4.53.3",
     "ubelt",
     "xdoctest>=0.10.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ tests = [
     "protobuf",
     "psutil",
     "pytest",
+    "pytest-order",
     "transformers==4.53.3",
     "ubelt",
     "xdoctest>=0.10.0",

--- a/tests/test_mmcv_ops_lite.py
+++ b/tests/test_mmcv_ops_lite.py
@@ -1,0 +1,42 @@
+# Copyright (c) VBTI. All rights reserved.
+"""Tests whether mmseg works when onedl-mmcv without ops is installed."""
+
+import sys
+import traceback
+import types
+
+import pytest
+
+
+@pytest.mark.order(0)
+def test_mmdet_import_without_mmcv_ops(monkeypatch):
+    # Simulate mmcv.ops not being present or failing to import
+
+    class OpsMock(types.ModuleType):
+
+        def __getattr__(self, name):
+            if name in {
+                    '__file__', '__name__', '__package__', '__loader__',
+                    '__spec__'
+            }:
+                return super().__getattribute__(name)
+            raise ModuleNotFoundError('No module named "mmcv._ext"')
+
+    ops_mock = OpsMock('mmcv.ops')
+    monkeypatch.setitem(sys.modules, 'mmcv.ops', ops_mock)
+    sys.modules.pop('mmcv._ext', None)
+
+    # Try importing mmdet
+    import mmdet  # noqa: F401
+    mmdet.__version__
+
+    from mmdet.utils import register_all_modules
+
+    try:
+        register_all_modules()  # should not raise import errors
+    except ModuleNotFoundError as e:
+        tb = traceback.format_tb(e.__traceback__)
+        last_entry = tb[-2] if tb else 'No traceback available'
+        assert False, (
+            'Import failed, onedl-mmcv.ops is not properly guarded in\n'
+            f"{last_entry}")

--- a/tests/test_mmcv_ops_lite.py
+++ b/tests/test_mmcv_ops_lite.py
@@ -27,7 +27,7 @@ def test_mmdet_import_without_mmcv_ops():
                         '__file__', '__name__', '__package__',
                         '__loader__', '__spec__'}:
                     return super().__getattribute__(name)
-                raise ModuleNotFoundError('No module named "mmcv._ext"')
+                raise ImportError('No module named "mmcv._ext"')
 
         ops_mock = OpsMock('mmcv.ops')
         sys.modules['mmcv.ops'] = ops_mock
@@ -40,7 +40,7 @@ def test_mmdet_import_without_mmcv_ops():
 
         try:
             register_all_modules()
-        except ModuleNotFoundError as e:
+        except ImportError as e:
             tb = traceback.format_tb(e.__traceback__)
             last_entry = tb[-2] if tb else 'No traceback available'
             print(

--- a/tests/test_mmcv_ops_lite.py
+++ b/tests/test_mmcv_ops_lite.py
@@ -1,42 +1,61 @@
 # Copyright (c) VBTI. All rights reserved.
-"""Tests whether mmseg works when onedl-mmcv without ops is installed."""
+"""Tests whether mmdet works when onedl-mmcv without ops is installed.
 
+The simulation runs in a subprocess so that the monkeypatched sys.modules does
+not persist into the rest of the pytest session.
+"""
+
+import subprocess
 import sys
-import traceback
-import types
-
-import pytest
+import textwrap
 
 
-@pytest.mark.order(0)
-def test_mmdet_import_without_mmcv_ops(monkeypatch):
-    # Simulate mmcv.ops not being present or failing to import
+def test_mmdet_import_without_mmcv_ops():
+    """Run the mmcv.ops-absent simulation in a fresh interpreter subprocess.
 
-    class OpsMock(types.ModuleType):
+    This avoids polluting sys.modules for later tests and removes the need for
+    pytest-order to control test sequencing.
+    """
+    script = textwrap.dedent("""\
+        import sys
+        import traceback
+        import types
 
-        def __getattr__(self, name):
-            if name in {
-                    '__file__', '__name__', '__package__', '__loader__',
-                    '__spec__'
-            }:
-                return super().__getattribute__(name)
-            raise ModuleNotFoundError('No module named "mmcv._ext"')
+        class OpsMock(types.ModuleType):
+            def __getattr__(self, name):
+                if name in {
+                        '__file__', '__name__', '__package__',
+                        '__loader__', '__spec__'}:
+                    return super().__getattribute__(name)
+                raise ModuleNotFoundError('No module named "mmcv._ext"')
 
-    ops_mock = OpsMock('mmcv.ops')
-    monkeypatch.setitem(sys.modules, 'mmcv.ops', ops_mock)
-    sys.modules.pop('mmcv._ext', None)
+        ops_mock = OpsMock('mmcv.ops')
+        sys.modules['mmcv.ops'] = ops_mock
+        sys.modules.pop('mmcv._ext', None)
 
-    # Try importing mmdet
-    import mmdet  # noqa: F401
-    mmdet.__version__
+        import mmdet  # noqa: F401
+        mmdet.__version__
 
-    from mmdet.utils import register_all_modules
+        from mmdet.utils import register_all_modules
 
-    try:
-        register_all_modules()  # should not raise import errors
-    except ModuleNotFoundError as e:
-        tb = traceback.format_tb(e.__traceback__)
-        last_entry = tb[-2] if tb else 'No traceback available'
-        assert False, (
-            'Import failed, onedl-mmcv.ops is not properly guarded in\n'
-            f"{last_entry}")
+        try:
+            register_all_modules()
+        except ModuleNotFoundError as e:
+            tb = traceback.format_tb(e.__traceback__)
+            last_entry = tb[-2] if tb else 'No traceback available'
+            print(
+                'Import failed, onedl-mmcv.ops is not properly guarded in\\n'
+                + last_entry,
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    """)
+
+    result = subprocess.run(
+        [sys.executable, '-c', script],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        'mmdet import without mmcv.ops failed in subprocess:\n' +
+        result.stderr)

--- a/uv.lock
+++ b/uv.lock
@@ -2094,6 +2094,7 @@ tests = [
     { name = "protobuf" },
     { name = "psutil" },
     { name = "pytest" },
+    { name = "pytest-order" },
     { name = "transformers" },
     { name = "ubelt" },
     { name = "xdoctest" },
@@ -2177,6 +2178,7 @@ tests = [
     { name = "protobuf" },
     { name = "psutil" },
     { name = "pytest" },
+    { name = "pytest-order" },
     { name = "transformers", specifier = "==4.53.3" },
     { name = "ubelt" },
     { name = "xdoctest", specifier = ">=0.10.0" },
@@ -2910,6 +2912,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-order"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/66/02ae17461b14a52ce5a29ae2900156b9110d1de34721ccc16ccd79419876/pytest_order-1.3.0.tar.gz", hash = "sha256:51608fec3d3ee9c0adaea94daa124a5c4c1d2bb99b00269f098f414307f23dde", size = 47544, upload-time = "2024-08-22T12:29:54.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/73/59b038d1aafca89f8e9936eaa8ffa6bb6138d00459d13a32ce070be4f280/pytest_order-1.3.0-py3-none-any.whl", hash = "sha256:2cd562a21380345dd8d5774aa5fd38b7849b6ee7397ca5f6999bbe6e89f07f6e", size = 14609, upload-time = "2024-08-22T12:29:53.156Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2094,7 +2094,6 @@ tests = [
     { name = "protobuf" },
     { name = "psutil" },
     { name = "pytest" },
-    { name = "pytest-order" },
     { name = "transformers" },
     { name = "ubelt" },
     { name = "xdoctest" },
@@ -2178,7 +2177,6 @@ tests = [
     { name = "protobuf" },
     { name = "psutil" },
     { name = "pytest" },
-    { name = "pytest-order" },
     { name = "transformers", specifier = "==4.53.3" },
     { name = "ubelt" },
     { name = "xdoctest", specifier = ">=0.10.0" },
@@ -2912,18 +2910,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
-]
-
-[[package]]
-name = "pytest-order"
-version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/66/02ae17461b14a52ce5a29ae2900156b9110d1de34721ccc16ccd79419876/pytest_order-1.3.0.tar.gz", hash = "sha256:51608fec3d3ee9c0adaea94daa124a5c4c1d2bb99b00269f098f414307f23dde", size = 47544, upload-time = "2024-08-22T12:29:54.512Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/73/59b038d1aafca89f8e9936eaa8ffa6bb6138d00459d13a32ce070be4f280/pytest_order-1.3.0-py3-none-any.whl", hash = "sha256:2cd562a21380345dd8d5774aa5fd38b7849b6ee7397ca5f6999bbe6e89f07f6e", size = 14609, upload-time = "2024-08-22T12:29:53.156Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Trying to reduce the dependency on mmcv.ops to allow users to use the 'lite' version (from pypi) where possible.

However, turns out that inference needs batched_nms op so results are limited. Next step could be to (re-)implement batched_nms using torchvision code.

## Modification

- put guards where mmcv.ops is imported and throw runtime errors instead when used
- update documentation
- update linting jobs to use python 3.12

## BC-breaking (Optional)

Before a ModuleNotFound error (or something similar) was thrown when the lite version of onedl-mmcv is installed. This is no longer the case and instead a RuntimError is thrown when trying to use an op which is not present.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMPreTrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
